### PR TITLE
fix(cli): resolve ESM __dirname bug in ada init

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,0 +1,18 @@
+/**
+ * lint-staged configuration.
+ *
+ * Uses function syntax for TypeScript checks so that `tsc --noEmit` runs
+ * against the full project config (not individual files). When tsc receives
+ * individual file arguments, it bypasses tsconfig include/exclude and module
+ * settings, causing false errors with ESM features like `import.meta`.
+ *
+ * See: Lesson #11 in agents/memory/bank.md
+ */
+export default {
+  'packages/**/*.{ts,js}': (stagedFiles) => [
+    `eslint --fix ${stagedFiles.join(' ')}`,
+    'npm run typecheck --workspaces',
+  ],
+  '*.md': ['prettier --write --parser markdown'],
+  '*.{json,yml,yaml}': ['prettier --write'],
+};

--- a/package.json
+++ b/package.json
@@ -39,17 +39,5 @@
   },
   "engines": {
     "node": ">=18.0.0"
-  },
-  "lint-staged": {
-    "packages/**/*.{ts,js}": [
-      "eslint --fix",
-      "npm run typecheck --workspaces"
-    ],
-    "*.md": [
-      "prettier --write --parser markdown"
-    ],
-    "*.{json,yml,yaml}": [
-      "prettier --write"
-    ]
   }
 }

--- a/packages/cli/src/commands/__tests__/init.test.ts
+++ b/packages/cli/src/commands/__tests__/init.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Regression tests for `ada init` command.
+ *
+ * Issue #16: ESM __dirname compatibility.
+ * The CLI uses ESM ("type": "module") but was referencing the CJS-only
+ * __dirname global, causing a ReferenceError at runtime.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+describe('ada init — ESM compatibility (#16)', () => {
+  it('should resolve __dirname via import.meta.url without throwing', () => {
+    // This is the exact pattern used in init.ts — verifies it works in ESM context
+    const filename = fileURLToPath(import.meta.url);
+    const dirname = path.dirname(filename);
+
+    expect(typeof dirname).toBe('string');
+    expect(dirname.length).toBeGreaterThan(0);
+    expect(path.isAbsolute(dirname)).toBe(true);
+  });
+
+  it('should resolve the CLI package root from the commands directory', () => {
+    // Mirrors the logic in copyTemplateFiles():
+    //   const cliRoot = path.dirname(path.dirname(__dirname));
+    // From dist/commands/ → going up 2 levels → packages/cli/
+    const filename = fileURLToPath(import.meta.url);
+    const dirname = path.dirname(filename);
+    const cliRoot = path.dirname(path.dirname(dirname));
+
+    // cliRoot should be a valid directory path
+    expect(typeof cliRoot).toBe('string');
+    expect(path.isAbsolute(cliRoot)).toBe(true);
+  });
+
+  it('should resolve templates directory from CLI root', () => {
+    // Full path resolution chain from init.ts:
+    //   cliRoot = ../../ from dist/commands/
+    //   templatesDir = cliRoot/../../templates
+    //   templateSource = templatesDir/agents
+    const filename = fileURLToPath(import.meta.url);
+    const dirname = path.dirname(filename);
+    const cliRoot = path.dirname(path.dirname(dirname));
+    const templatesDir = path.join(cliRoot, '..', '..', 'templates');
+    const templateSource = path.join(templatesDir, 'agents');
+
+    // Verify the path chain resolves to valid absolute paths (no undefined segments)
+    expect(path.isAbsolute(templatesDir)).toBe(true);
+    expect(path.isAbsolute(templateSource)).toBe(true);
+    expect(templateSource).toContain('templates');
+    expect(templateSource).toContain('agents');
+  });
+
+  it('should not use CJS __dirname global directly', async () => {
+    // Read the init.ts source and verify it imports fileURLToPath
+    const { readFile } = await import('node:fs/promises');
+    const initSource = await readFile(
+      path.resolve(
+        path.dirname(fileURLToPath(import.meta.url)),
+        '..',
+        'init.ts'
+      ),
+      'utf-8'
+    );
+
+    // Must import fileURLToPath for ESM __dirname
+    expect(initSource).toContain("import { fileURLToPath } from 'node:url'");
+    expect(initSource).toContain('fileURLToPath(import.meta.url)');
+
+    // Should define __dirname at module scope (not use the CJS global directly in function body)
+    expect(initSource).toContain('const __dirname = path.dirname(__filename)');
+  });
+});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -8,7 +8,16 @@
 import { Command } from 'commander';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
+
+/**
+ * ESM-compatible __dirname equivalent.
+ * CJS globals (__dirname, __filename) are not available in ESM modules.
+ */
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 import { DEFAULT_CONFIG } from '@ada/core';
 import type { Roster, RotationState, AdaConfig } from '@ada/core';
 


### PR DESCRIPTION
## Summary

Fixes **Issue #16 (P0)** — `ada init` fails with `__dirname is not defined`.

## Root Cause

The CLI package is ESM (`"type": "module"` in package.json) but `init.ts` line 309 referenced `__dirname`, which is a CommonJS-only global. This caused a `ReferenceError` at runtime, blocking all new user onboarding.

## Fix

1. **ESM __dirname shim** — Added `fileURLToPath(import.meta.url)` + `path.dirname()` at module scope in `init.ts`, replacing the CJS `__dirname` global with the standard ESM equivalent.

2. **lint-staged config fix** — Migrated from inline JSON config to `lint-staged.config.mjs` with function syntax. The old config passed individual file paths to `tsc --noEmit`, which bypassed the tsconfig `module: "ESNext"` setting and rejected `import.meta` as invalid. The new config runs typecheck on the full project.

## Changes

- `packages/cli/src/commands/init.ts` — Add `fileURLToPath` import, define ESM-compatible `__dirname`
- `lint-staged.config.mjs` — New file, function-based lint-staged config
- `package.json` — Remove inline lint-staged config (moved to external file)
- `packages/cli/src/commands/__tests__/init.test.ts` — 4 regression tests

## Testing

- ✅ `npm run build --workspaces` passes
- ✅ `npm run typecheck --workspaces` passes
- ✅ 4 new regression tests pass (vitest)
- ✅ Pre-commit hooks (eslint + typecheck + prettier) pass

## Verification

After merging, `ada init` should work correctly:
```bash
mkdir test-project && cd test-project
git init
npx ada init --team-size large --focus research
# ✅ Should create agents/ directory without __dirname error
```

Closes #16

---
*⚙️ Engineering — The Builder (Cycle 34)*