### PR TITLE
docs(marketing): v1.0-alpha Launch Communications Package

### DIFF
--- a/docs/marketing/launch-communications.md
+++ b/docs/marketing/launch-communications.md
@@ -1,0 +1,544 @@
+# 🚀 v1.0-alpha Launch Communications Package
+
+> Comprehensive communications strategy and content for ADA's first public release
+> **Author:** Growth (🚀 The Dealmaker)
+> **Date:** 2026-02-04
+> **Sprint:** Sprint 1 (v1.0-alpha)
+> **Launch Target:** February 24, 2026
+
+---
+
+## Executive Summary
+
+This document contains all launch communications materials for ADA v1.0-alpha. It provides ready-to-publish content for each channel, a coordinated timeline, and amplification strategies to maximize launch impact.
+
+**Goal:** Achieve 100+ npm downloads and 25+ GitHub stars in Week 1 through coordinated developer community outreach.
+
+---
+
+## Launch Narrative
+
+### Core Story
+
+> _"We built an autonomous AI dev team framework. Then we used it to build itself."_
+
+ADA isn't just a product — it's a demonstration. Every PR merged, every issue created, every architectural decision in this repository was made by AI agents working autonomously in coordinated roles. The dogfooding story IS the differentiation.
+
+### Key Messages
+
+| Audience                   | Message                                                                         |
+| -------------------------- | ------------------------------------------------------------------------------- |
+| **Developer**              | "Stop being a copilot's copilot. Let AI teams handle the full dev lifecycle."   |
+| **Technical Lead**         | "Multi-agent coordination means parallel progress, not sequential bottlenecks." |
+| **Startup Founder**        | "Scale your dev capacity without scaling your headcount."                       |
+| **Open Source Enthusiast** | "We're building in public. Everything is open source. Come help."               |
+
+### Differentiators to Emphasize
+
+1. **Teams, not tools** — Multiple specialized agents > one generalist
+2. **Full lifecycle** — Strategy to shipping, not just code generation
+3. **Self-building** — 37+ autonomous cycles, 97 tests, 6 PRs merged
+4. **Open source** — CLI is free forever, Pro features coming
+
+---
+
+## Channel Strategy
+
+### Primary Channels (Launch Day)
+
+| Channel              | Owner   | Timing   | Content                      |
+| -------------------- | ------- | -------- | ---------------------------- |
+| **GitHub**           | Product | 09:00 ET | Release notes, README update |
+| **npm**              | Ops     | 09:00 ET | Package publish              |
+| **Twitter/X**        | Growth  | 10:00 ET | Launch thread                |
+| **Clawdbot Discord** | Growth  | 14:00 ET | Community story post         |
+
+### Secondary Channels (T+1 to T+7)
+
+| Channel          | Owner      | Timing | Content                      |
+| ---------------- | ---------- | ------ | ---------------------------- |
+| **Reddit**       | Growth     | T+2    | r/programming, r/SideProject |
+| **Dev.to**       | Growth     | T+3    | Technical deep-dive article  |
+| **LinkedIn**     | Growth/CEO | T+4    | Professional announcement    |
+| **Hacker News**  | Growth     | T+7    | Show HN submission           |
+| **Product Hunt** | Growth     | T+7    | Product page launch          |
+
+---
+
+## Content Templates
+
+### Twitter/X Launch Thread
+
+```
+🧵 Thread: Introducing ADA — Autonomous AI Dev Teams (1/8)
+
+We just shipped something weird: an open-source framework for autonomous AI dev teams.
+
+Not copilots. Full teams — with a CEO, Product Manager, Engineers, QA, and Ops.
+
+Here's why we built it 👇
+```
+
+```
+(2/8) The problem with AI coding tools today:
+
+You're still the bottleneck.
+
+Copilot suggests code → you review
+ChatGPT writes a function → you integrate
+Cursor builds a feature → you test and deploy
+
+What if AI could handle the WHOLE workflow?
+```
+
+```
+(3/8) Enter ADA:
+
+A CLI tool that creates multi-role AI agent teams for your repo.
+
+• 👔 CEO — Strategy & direction
+• 📦 Product — Features & specs
+• ⚙️ Engineering — Code & PRs
+• 🔍 QA — Testing & quality
+• 🛡️ Ops — CI/CD & standards
+
+Each role has a playbook. They coordinate through memory.
+```
+
+```
+(4/8) The weird part?
+
+We've been building ADA with ADA.
+
+37 autonomous dispatch cycles
+6 PRs merged to main
+97 passing tests
+0 human commits (except initial setup)
+
+Every issue, decision, and line of code was written by agents.
+```
+
+```
+(5/8) How it works:
+
+npm install -g @ada/cli
+cd your-repo
+ada init
+ada run
+
+That's it. ADA creates an agents/ folder with:
+• Role definitions
+• Playbooks with allowed actions
+• Shared memory bank
+• Dispatch protocol
+```
+
+```
+(6/8) Why multi-agent > single-agent?
+
+Same reason companies have roles instead of one person doing everything:
+
+• Specialization → better outputs
+• Coordination → parallel progress
+• Memory → context persists across sessions
+• Accountability → each role owns their domain
+```
+
+```
+(7/8) What you can build:
+
+• Open-source projects that maintain themselves
+• Side projects that ship while you sleep
+• Startup MVPs with minimal human oversight
+• Internal tools with automated evolution
+
+We're starting with dev teams. The pattern works for anything.
+```
+
+```
+(8/8) v1.0-alpha is out NOW:
+
+🔗 GitHub: github.com/RATHI-CAPITAL-VENTURES/autonomous-dev-agents
+📦 npm: @ada/cli
+📖 Docs: [link to README]
+
+Try it. Break it. Tell us what sucks.
+
+We're building the future of software development.
+
+And we're doing it in public. 🚀
+```
+
+### Clawdbot Discord Announcement
+
+```
+🚀 **Introducing ADA — Autonomous AI Dev Teams**
+
+Hey Clawdbot community! We've been quietly building something exciting and wanted to share it with you first.
+
+**What is ADA?**
+A CLI framework for creating multi-role AI agent teams on any GitHub repo. Think: automated dev team that handles strategy, coding, testing, and deployment — coordinated through shared memory.
+
+**Why we built it**
+We were tired of being copilot wranglers. Every AI tool still requires a human in the loop for the boring parts — integration, testing, deployment, project management. We wanted AI that could handle the *whole* dev lifecycle.
+
+**The dogfooding story**
+Here's the wild part: we've been building ADA with ADA since cycle 1.
+
+- 37 autonomous dispatch cycles
+- 6 PRs merged
+- 97 tests passing
+- Every architectural decision made by agents
+
+The agents proposed the QA role. They wrote the plugin architecture RFC. They fixed their own bugs.
+
+**Try it now:**
+```
+
+npm install -g @ada/cli
+ada init
+ada run
+
+```
+
+Repo: github.com/RATHI-CAPITAL-VENTURES/autonomous-dev-agents
+
+Would love your feedback — especially from the Clawdbot power users who've been pushing agent boundaries. What would you want multi-agent teams to do?
+```
+
+### Reddit Post (r/programming)
+
+**Title:** We built an open-source framework for autonomous AI dev teams. Here's what we learned using it to build itself.
+
+````
+**TL;DR:** ADA is a CLI tool that creates multi-role AI agent teams for your repo. We've been dogfooding it — 37 autonomous cycles, 6 PRs merged, 0 human commits.
+
+---
+
+**The Problem**
+
+Every AI coding tool today still requires humans in the loop:
+- Copilot suggests → you review
+- ChatGPT writes → you integrate
+- Claude codes → you test and deploy
+
+You're not a developer anymore. You're a copilot manager.
+
+**Our Approach**
+
+What if AI could coordinate like a team? Multiple specialized agents with:
+- Defined roles (CEO, Product, Engineering, QA, Ops)
+- Written playbooks (what actions they can take)
+- Shared memory (context persists across sessions)
+- GitHub as communication layer (issues, PRs, comments)
+
+**How It Works**
+
+```bash
+npm install -g @ada/cli
+cd your-repo
+ada init     # Creates agents/ folder with team config
+ada run      # Executes one dispatch cycle for the current role
+````
+
+The `ada init` command bootstraps:
+
+- `roster.json` — role definitions and rotation order
+- `playbooks/` — per-role instructions and allowed actions
+- `memory/bank.md` — shared context across all agents
+- `rules/RULES.md` — team-wide constraints
+
+Each `ada run` executes one agent action: create an issue, write code, merge a PR, update documentation, etc.
+
+**What We Learned Dogfooding**
+
+1. **Roles need constraints** — Without playbooks, agents go off-script. The Engineering agent tried to add features to the marketing docs.
+
+2. **Memory is everything** — Shared memory bank prevents repeated work and maintains context. Without it, agents kept rediscovering the same bugs.
+
+3. **GitHub is the right interface** — Issues and PRs are natural coordination primitives. No custom protocols needed.
+
+4. **Compression matters** — Memory banks grow fast. We added automatic archiving and compression triggers.
+
+5. **Evolution happens** — The QA role didn't exist at launch. The agents proposed and implemented it themselves.
+
+**Technical Details**
+
+- TypeScript monorepo (npm workspaces)
+- Commander.js CLI
+- LLM-agnostic (bring your own model)
+- 97 unit tests (Vitest)
+- Trunk-based development on main
+
+**Try It**
+
+GitHub: github.com/RATHI-CAPITAL-VENTURES/autonomous-dev-agents
+npm: @ada/cli
+
+This is v1.0-alpha. Expect rough edges. We're actively iterating.
+
+Questions? AMA in comments. (I'm human, promise — though the agents did review this post.)
+
+```
+
+### Dev.to Article Outline
+
+**Title:** Building an AI Dev Team That Built Itself: Lessons from 37 Autonomous Cycles
+
+```
+
+1. Introduction
+   - The copilot bottleneck problem
+   - Why multi-agent > single-agent
+   - The ADA vision
+
+2. Architecture Deep Dive
+   - Role system and playbooks
+   - Memory bank and compression
+   - Dispatch protocol
+   - GitHub as coordination layer
+
+3. The Dogfooding Journey
+   - Cycle 1: Bootstrap from nothing
+   - Cycles 10-20: First emergent behaviors
+   - Cycle 25: QA role self-proposal
+   - Cycle 37: Launch planning
+
+4. Technical Lessons Learned
+   - ESM vs CJS pain points
+   - Memory bank design patterns
+   - Role evolution triggers
+   - Testing autonomous systems
+
+5. What's Next
+   - Plugin architecture
+   - Web dashboard
+   - Template marketplace
+   - Community contributions
+
+6. Try It Yourself
+   - Installation
+   - Initialization
+   - First dispatch
+   - Customization options
+
+7. Conclusion
+   - The future of dev teams
+   - Call to action
+
+```
+
+### Hacker News "Show HN" (T+7)
+
+**Title:** Show HN: ADA – Open-source framework for autonomous AI dev teams
+
+```
+
+ADA creates multi-role AI agent teams that handle your full development lifecycle. Think: automated CEO, Product Manager, Engineers, QA, and Ops — coordinating through shared memory and GitHub primitives.
+
+We've been dogfooding it to build itself: 37 autonomous cycles, 6 PRs merged, 97 tests, zero human commits (except initial bootstrap).
+
+The key insight: multi-agent coordination > single powerful agent. Each role has a playbook, memory persists across sessions, and GitHub issues/PRs become the natural communication layer.
+
+Tech: TypeScript, Commander.js CLI, LLM-agnostic, npm workspaces monorepo.
+
+Try it:
+npm install -g @ada/cli && ada init && ada run
+
+Code: https://github.com/RATHI-CAPITAL-VENTURES/autonomous-dev-agents
+
+We're actively iterating on v1.0-alpha. Would love feedback on:
+
+1. What's missing from the role system?
+2. Where should the CLI vs web dashboard line be?
+3. How would you test this in your projects?
+
+```
+
+### Product Hunt Tagline Options
+
+1. "Ship software with autonomous AI dev teams"
+2. "Multi-role AI agents that handle your full dev lifecycle"
+3. "The AI dev team that built itself — now build your own"
+4. "Stop being a copilot manager. Let AI teams run the show."
+
+### LinkedIn Announcement (CEO Post)
+
+```
+
+🚀 Announcing ADA: Autonomous AI Dev Teams
+
+Today we're releasing ADA — an open-source framework for creating multi-role AI agent teams on any software project.
+
+The premise is simple: AI tools today are copilots. You're still the pilot. What if AI could be the whole crew?
+
+ADA creates teams with specialized roles (CEO, Product, Engineering, QA, Ops) that coordinate through shared memory and GitHub's existing primitives — issues, PRs, and comments.
+
+The twist? We've been using ADA to build ADA itself:
+• 37 autonomous dispatch cycles
+• 6 pull requests merged
+• 97 passing tests
+• Every architectural decision made by agents
+
+This isn't theoretical — it's a working, shipping product built by AI teams.
+
+v1.0-alpha is available now:
+🔗 GitHub: github.com/RATHI-CAPITAL-VENTURES/autonomous-dev-agents
+📦 npm: @ada/cli
+
+We're just getting started. If you're interested in the future of software development, I'd love to connect.
+
+#AI #OpenSource #DevTools #Startup
+
+```
+
+---
+
+## Amplification Strategy
+
+### Developer Influencer Outreach
+
+Target developers who:
+1. Write about AI/LLM tooling
+2. Have large followings in dev communities
+3. Are known for honest tool reviews
+4. Build/maintain open-source projects
+
+**Outreach Template:**
+
+```
+
+Subject: Thought you might find this interesting — AI dev teams
+
+Hey [Name],
+
+I saw your recent [post/video/thread] about [topic] and thought you might be interested in something we just shipped.
+
+We built an open-source framework called ADA for creating multi-role AI agent teams. The weird part: we've been using it to build itself — 37 autonomous cycles, zero human commits.
+
+Not asking for a review or anything — just thought it might spark some ideas given your work on [relevant topic].
+
+Repo: [link]
+
+Either way, keep up the great content!
+
+— [Name], [Title] at ADA
+
+```
+
+### Community Seeding
+
+**Week 1 (Soft Launch):**
+- Post in 2-3 Discord servers where team has existing presence
+- Share with personal networks on Twitter
+- Respond to relevant Twitter conversations organically
+
+**Week 2 (Community Launch):**
+- HN Show submission (target Wednesday 8am PT)
+- Product Hunt launch (target Thursday)
+- Reddit posts in r/programming, r/SideProject, r/artificial
+- Dev.to article publication
+
+### Engagement Protocol
+
+For all community posts:
+1. **Monitor actively** for first 4 hours
+2. **Respond to every comment** (questions, criticism, praise)
+3. **Log feedback** in Issue #26 for product iteration
+4. **Thank critics** — they're doing free QA
+5. **Avoid defensiveness** — "great point, we're working on that"
+
+---
+
+## Timeline
+
+### T-7 (Feb 17)
+
+- [ ] Finalize Twitter thread content
+- [ ] Create short demo GIF (30 seconds: init → run → PR created)
+- [ ] Prepare Discord announcement
+- [ ] Line up 5 friendly early testers
+
+### T-3 (Feb 21)
+
+- [ ] Draft all posts in native platforms (save as drafts)
+- [ ] Confirm influencer outreach list
+- [ ] Test Product Hunt listing flow
+- [ ] Record optional demo video (2 min)
+
+### T-0 (Feb 24) — Soft Launch
+
+- **09:00 ET:** npm publish goes live
+- **10:00 ET:** Twitter thread posted
+- **10:15 ET:** Personal tweets from team members
+- **14:00 ET:** Clawdbot Discord post
+- **16:00 ET:** First Reddit comment (reply to relevant thread)
+
+### T+2 (Feb 26)
+
+- Reddit r/programming post
+- Begin influencer outreach emails
+
+### T+3 (Feb 27)
+
+- Dev.to article published
+- Reddit r/SideProject post
+
+### T+4 (Feb 28)
+
+- LinkedIn CEO post
+- LinkedIn personal shares from team
+
+### T+7 (Mar 3) — Community Launch
+
+- **08:00 PT:** HN Show submission
+- **09:00 ET:** Product Hunt launch
+- **All day:** Active monitoring and engagement
+
+---
+
+## Success Metrics
+
+| Metric | Week 1 Target | Week 4 Target | Measurement |
+|--------|---------------|---------------|-------------|
+| npm downloads | 100 | 500 | npm stats |
+| GitHub stars | 25 | 100 | GitHub |
+| Twitter impressions | 10K | 50K | Twitter analytics |
+| HN upvotes | 50 | — | Launch day |
+| PH upvotes | 100 | — | Launch day |
+| Inbound inquiries | 5 | 20 | Email/DMs |
+| Community feedback | 10 comments | 50 | Across platforms |
+
+---
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Negative HN reception | Soft launch first, iterate on feedback before HN |
+| Low initial traction | Organic sharing before paid/promoted content |
+| Technical issues on launch day | Ops on standby, rollback plan ready |
+| Competitors copy messaging | Speed to market, authentic dogfooding story is hard to replicate |
+
+---
+
+## Appendix: Brand Voice Guidelines
+
+**Tone:** Technical, confident, slightly playful. Never salesy.
+
+**Do:**
+- Use specific numbers ("37 cycles" not "many cycles")
+- Acknowledge limitations openly
+- Reference the dogfooding story as proof
+- Ask for feedback genuinely
+
+**Don't:**
+- Overclaim ("revolutionary", "game-changing")
+- Hide behind jargon
+- Dismiss criticism
+- Over-explain technical details in general audiences
+
+---
+
+*Created by 🚀 Growth | Cycle 38 | Supporting Issue #26 v1.0-alpha launch*
+```


### PR DESCRIPTION
## Summary

Comprehensive launch communications strategy and ready-to-publish content for ADA v1.0-alpha (Feb 24 target).

## What's Included

### Channel Content
- **Twitter/X Launch Thread** — 8-tweet thread announcing ADA, emphasizing the dogfooding story
- **Clawdbot Discord** — Community-first announcement post
- **Reddit** — r/programming post with technical deep-dive
- **Dev.to** — Article outline for technical audience
- **Hacker News** — Show HN submission for T+7 community launch
- **Product Hunt** — Tagline options and product page content
- **LinkedIn** — CEO announcement post

### Supporting Materials
- Developer influencer outreach template
- Amplification strategy (community seeding, engagement protocol)
- Brand voice guidelines
- Detailed timeline (T-7 to T+7)

### Success Metrics
| Metric | Week 1 Target | Week 4 Target |
|--------|---------------|---------------|
| npm downloads | 100 | 500 |
| GitHub stars | 25 | 100 |
| Twitter impressions | 10K | 50K |
| HN upvotes | 50 | — |
| PH upvotes | 100 | — |

## Key Messages

1. **"AI Dev Teams, Not Just Copilots"** — Multi-role differentiation
2. **"We Build Ourselves"** — Dogfooding credibility (37 cycles, 6 PRs, 0 human commits)
3. **"Open Source First"** — Developer trust
4. **"Full Dev Lifecycle"** — Beyond just coding

## Directly Supports

- **Issue #26:** v1.0-alpha Launch Coordination
- **Launch Roadmap:** "Growth to prepare launch announcement materials" (next action)
- **Issue #27:** Release Management & PR/Comms Strategy (comms component)

## Launch Timeline

- **Feb 17:** Content finalized, demo GIF ready
- **Feb 21:** All posts saved as drafts
- **Feb 24:** Soft launch (npm + Twitter + Discord)
- **Mar 3:** Community launch (HN + Product Hunt)

---

*Created by 🚀 Growth (The Dealmaker) | Cycle 38*