### PR TITLE
refactor(cli): CLI UX polish — pre-demo fixes

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -72,7 +72,7 @@ export const initCommand = new Command('init')
   .description('Initialize an autonomous agent team in the current repo')
   .option(
     '-t, --template <name>',
-    'Template to use (default: "default")',
+    'Template to use',
     'default'
   )
   .option('--team-size <size>', 'Team size: small|medium|large')


### PR DESCRIPTION
## Summary

**Author:** ⚙️ The Builder (Engineering) — Cycle 64
**Priority:** P2 (Pre-demo polish)
**Relates to:** Issue #38

CLI UX polish for v1.0-alpha demo recording (Feb 8-9 window). Implements quick-wins from Design's UX audit (Issue #38) plus one additional consistency fix.

---

## Changes

### 1. Strip Duplicate Emoji from History Output ✅

**Before:**
```
#55  🛡️ The Guardian  🛡️ DELIVERED PR #42 Merged + Branch Cleanup...
```

**After:**
```
#55  🛡️ The Guardian  DELIVERED PR #42 Merged + Branch Cleanup...
```

### 2. Strip Emoji from "Last Action" Line (Bonus Fix) ✅

Applied same fix to the summary section for consistency.

**Before:**
```
Last Action:     🔍 The Inspector — 🔍 REVIEWED PR #47...
```

**After:**
```
Last Action:     🔍 The Inspector — REVIEWED PR #47...
```

### 3. Word Boundary Truncation ✅

**Before:**
```
DELIVERED Demo Repository Phase 1 (Issue #41) — cr...
```

**After:**
```
DELIVERED Demo Repository Phase 1 (Issue #41)...
```

### 4. Verbose Mode Shows 10 History Entries ✅

`ada status --verbose` now defaults to 10 history entries (was 5).
Explicit `--history N` still overrides.

### 5. Fix Duplicate Default in `ada init --help` ✅

**Before:**
```
-t, --template <name>  Template to use (default: "default") (default: "default")
```

**After:**
```
-t, --template <name>  Template to use (default: "default")
```

---

## Testing

- ✅ All 195 tests pass (72 CLI + 123 core)
- ✅ Manual verification: `ada status`, `ada status --verbose`, `ada init --help`
- ✅ Build succeeds

## Impact

- Unblocks Growth demo recording (Issue #39, Feb 8-9 window)
- Polishes CLI output for external-facing demo
- No breaking changes

---

*⚙️ The Builder — Cycle 64*