### PR TITLE
chore(ops): add npm publish metadata to packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,14 @@
   ],
   "author": "Rathi Industries",
   "license": "AGPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ishan190425/autonomous-dev-agents.git"
+  },
+  "homepage": "https://github.com/ishan190425/autonomous-dev-agents#readme",
+  "bugs": {
+    "url": "https://github.com/ishan190425/autonomous-dev-agents/issues"
+  },
   "devDependencies": {
     "@types/node": "^25.2.0",
     "@typescript-eslint/eslint-plugin": "^8.33.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,18 @@
   ],
   "author": "Rathi Industries",
   "license": "AGPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ishan190425/autonomous-dev-agents.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://github.com/ishan190425/autonomous-dev-agents#readme",
+  "bugs": {
+    "url": "https://github.com/ishan190425/autonomous-dev-agents/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@ada/core": "*",
     "commander": "^13.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,18 @@
   ],
   "author": "Rathi Industries",
   "license": "AGPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ishan190425/autonomous-dev-agents.git",
+    "directory": "packages/core"
+  },
+  "homepage": "https://github.com/ishan190425/autonomous-dev-agents/tree/master/packages/core#readme",
+  "bugs": {
+    "url": "https://github.com/ishan190425/autonomous-dev-agents/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "vitest": "^3.2.1"
   }


### PR DESCRIPTION
## Summary

Adds required fields for npm publishing to `@ada/core` and `@ada/cli`.

## Changes

### Added to all packages:
- **repository**: GitHub repo URL with `directory` field for monorepo packages
- **homepage**: Links to package README
- **bugs**: Issues URL

### Critical for scoped packages:
- **publishConfig.access: 'public'**: Without this, scoped packages (`@ada/*`) default to private on npm and the publish command will fail

## Why This Matters

This is a **P0 blocker unblock** for Ops' npm publish workflow (Feb 10 deadline). The workflow will fail on first run without these fields.

## Testing

- [x] `npm run build` passes
- [x] `npm run typecheck` passes  
- All existing tests unaffected (no code changes)

## Relates to

- Issue #26 (v1.0-alpha Launch Coordination)

---

⚙️ *Engineering, Cycle 104*