### PR TITLE
feat(cli): implement stop, pause, and resume commands

### DIFF
--- a/packages/cli/src/commands/__tests__/control.test.ts
+++ b/packages/cli/src/commands/__tests__/control.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for stop, pause, and resume commands.
+ *
+ * Tests command structure, help text, and option validation.
+ * Full integration tests would require mock file system.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { stopCommand } from '../stop.js';
+import { pauseCommand } from '../pause.js';
+import { resumeCommand } from '../resume.js';
+
+describe('stopCommand', () => {
+  it('should have correct name', () => {
+    expect(stopCommand.name()).toBe('stop');
+  });
+
+  it('should have description', () => {
+    expect(stopCommand.description()).toBeTruthy();
+    expect(stopCommand.description()).toContain('stop');
+  });
+
+  it('should have --force option', () => {
+    const forceOption = stopCommand.options.find(
+      (o) => o.long === '--force' || o.short === '-f'
+    );
+    expect(forceOption).toBeDefined();
+  });
+
+  it('should have --dir option', () => {
+    const dirOption = stopCommand.options.find((o) => o.long === '--dir');
+    expect(dirOption).toBeDefined();
+  });
+});
+
+describe('pauseCommand', () => {
+  it('should have correct name', () => {
+    expect(pauseCommand.name()).toBe('pause');
+  });
+
+  it('should have description', () => {
+    expect(pauseCommand.description()).toBeTruthy();
+    expect(pauseCommand.description()).toContain('pause');
+  });
+
+  it('should have --reason option', () => {
+    const reasonOption = pauseCommand.options.find(
+      (o) => o.long === '--reason' || o.short === '-r'
+    );
+    expect(reasonOption).toBeDefined();
+  });
+
+  it('should have --dir option', () => {
+    const dirOption = pauseCommand.options.find((o) => o.long === '--dir');
+    expect(dirOption).toBeDefined();
+  });
+
+  it('should have --no-commit option', () => {
+    const commitOption = pauseCommand.options.find(
+      (o) => o.long === '--no-commit'
+    );
+    expect(commitOption).toBeDefined();
+  });
+});
+
+describe('resumeCommand', () => {
+  it('should have correct name', () => {
+    expect(resumeCommand.name()).toBe('resume');
+  });
+
+  it('should have description', () => {
+    expect(resumeCommand.description()).toBeTruthy();
+    expect(resumeCommand.description().toLowerCase()).toContain('resume');
+  });
+
+  it('should have --dir option', () => {
+    const dirOption = resumeCommand.options.find((o) => o.long === '--dir');
+    expect(dirOption).toBeDefined();
+  });
+
+  it('should have --no-commit option', () => {
+    const commitOption = resumeCommand.options.find(
+      (o) => o.long === '--no-commit'
+    );
+    expect(commitOption).toBeDefined();
+  });
+});

--- a/packages/cli/src/commands/pause.ts
+++ b/packages/cli/src/commands/pause.ts
@@ -1,0 +1,86 @@
+/**
+ * `ada pause` — Pause dispatch cycles.
+ *
+ * Sets a paused flag in rotation.json to prevent future cycles
+ * from executing until `ada resume` is called.
+ */
+
+import { Command } from 'commander';
+import { readRotationState, writeRotationState } from '@ada/core';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
+
+export const pauseCommand = new Command('pause')
+  .description('Pause dispatch — set paused flag to prevent future cycles')
+  .option('-r, --reason <text>', 'Reason for pausing')
+  .option('-d, --dir <path>', 'Agents directory (default: "agents/")', 'agents')
+  .option('--no-commit', 'Skip git commit after pausing')
+  .action(
+    async (options: {
+      reason?: string;
+      dir: string;
+      commit: boolean;
+    }) => {
+      const cwd = process.cwd();
+      const statePath = path.join(cwd, options.dir, 'state', 'rotation.json');
+
+      console.log('⏸️  ADA Pause');
+      console.log();
+
+      try {
+        // Read current state
+        const state = await readRotationState(statePath);
+
+        if (state.paused) {
+          console.log('ℹ️  ADA is already paused.');
+          console.log(`   Paused at: ${state.paused_at}`);
+          if (state.pause_reason) {
+            console.log(`   Reason: ${state.pause_reason}`);
+          }
+          return;
+        }
+
+        // Set paused state
+        const now = new Date().toISOString();
+        const reason = options.reason || 'Manual pause via ada pause';
+
+        state.paused = true;
+        state.paused_at = now;
+        state.pause_reason = reason;
+
+        // Write updated state
+        await writeRotationState(statePath, state);
+
+        console.log('✅ ADA is now paused.');
+        console.log(`   Time: ${now}`);
+        console.log(`   Reason: ${reason}`);
+        console.log();
+        console.log('   Future dispatch cycles will be skipped until you run:');
+        console.log('   ada resume');
+
+        // Commit the change
+        if (options.commit) {
+          try {
+            const relativeStatePath = path.relative(cwd, statePath);
+            execSync(`git add "${relativeStatePath}"`, { cwd, stdio: 'pipe' });
+            execSync(
+              `git commit -m "chore(agents): pause dispatch — ${reason.substring(0, 50)}"`,
+              { cwd, stdio: 'pipe' }
+            );
+            execSync('git push', { cwd, stdio: 'pipe' });
+            console.log();
+            console.log('📤 Changes committed and pushed.');
+          } catch {
+            console.log();
+            console.log('⚠️  Git commit skipped (no changes or git error).');
+          }
+        }
+      } catch (err) {
+        console.error('❌ Pause failed:', (err as Error).message);
+        console.log();
+        console.log('   Make sure you are in a repo with ADA initialized.');
+        console.log('   Run `ada init` first if needed.');
+        process.exit(1);
+      }
+    }
+  );

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -1,0 +1,82 @@
+/**
+ * `ada resume` — Resume dispatch cycles.
+ *
+ * Clears the paused flag in rotation.json, allowing dispatch
+ * cycles to execute again.
+ */
+
+import { Command } from 'commander';
+import { readRotationState, writeRotationState } from '@ada/core';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
+
+export const resumeCommand = new Command('resume')
+  .description('Resume dispatch — clear paused flag to allow cycles')
+  .option('-d, --dir <path>', 'Agents directory (default: "agents/")', 'agents')
+  .option('--no-commit', 'Skip git commit after resuming')
+  .action(
+    async (options: {
+      dir: string;
+      commit: boolean;
+    }) => {
+      const cwd = process.cwd();
+      const statePath = path.join(cwd, options.dir, 'state', 'rotation.json');
+
+      console.log('▶️  ADA Resume');
+      console.log();
+
+      try {
+        // Read current state
+        const state = await readRotationState(statePath);
+
+        if (!state.paused) {
+          console.log('ℹ️  ADA is not paused — already running.');
+          console.log(`   Last run: ${state.last_run || '(never)'}`);
+          console.log(`   Cycle count: ${state.cycle_count}`);
+          return;
+        }
+
+        // Store pause info for display
+        const pausedAt = state.paused_at;
+        const pauseReason = state.pause_reason;
+
+        // Clear paused state
+        delete state.paused;
+        delete state.paused_at;
+        delete state.pause_reason;
+
+        // Write updated state
+        await writeRotationState(statePath, state);
+
+        console.log('✅ ADA is now resumed.');
+        console.log();
+        console.log('   Pause info (cleared):');
+        console.log(`   - Paused at: ${pausedAt || '(unknown)'}`);
+        console.log(`   - Reason: ${pauseReason || '(none)'}`);
+        console.log();
+        console.log('   Dispatch cycles will now execute normally.');
+
+        // Commit the change
+        if (options.commit) {
+          try {
+            const relativeStatePath = path.relative(cwd, statePath);
+            execSync(`git add "${relativeStatePath}"`, { cwd, stdio: 'pipe' });
+            execSync('git commit -m "chore(agents): resume dispatch"', {
+              cwd,
+              stdio: 'pipe',
+            });
+            execSync('git push', { cwd, stdio: 'pipe' });
+            console.log('📤 Changes committed and pushed.');
+          } catch {
+            console.log('⚠️  Git commit skipped (no changes or git error).');
+          }
+        }
+      } catch (err) {
+        console.error('❌ Resume failed:', (err as Error).message);
+        console.log();
+        console.log('   Make sure you are in a repo with ADA initialized.');
+        console.log('   Run `ada init` first if needed.');
+        process.exit(1);
+      }
+    }
+  );

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -51,6 +51,22 @@ export const runCommand = new Command('run')
       console.log(`🏭 ADA Dispatch Cycle ${cycleNumber}\n`);
 
       try {
+        // Check for paused state before dispatch
+        const statePath = path.join(cwd, options.dir, 'state', 'rotation.json');
+        const initialState = await readRotationState(statePath).catch(() => null);
+        
+        if (initialState?.paused) {
+          console.log('⏸️  ADA is paused.');
+          console.log();
+          console.log(`   Paused at: ${initialState.paused_at || '(unknown)'}`);
+          if (initialState.pause_reason) {
+            console.log(`   Reason: ${initialState.pause_reason}`);
+          }
+          console.log();
+          console.log('   Use `ada resume` to continue dispatch cycles.');
+          process.exit(0);
+        }
+
         // Phase 1: Context Load
         console.log('📋 Phase 1: Loading context...');
         const context = await loadContext(cwd, { agentsDir: options.dir });

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -288,6 +288,17 @@ function printDefaultStatus(data: StatusData, historyCount: number): void {
   // Header
   console.log(chalk.bold.blue(`🤖 ADA Status — ${roster.product}\n`));
 
+  // Paused state warning
+  if (rotation.paused) {
+    console.log(chalk.bgYellow.black(' ⏸️  PAUSED '));
+    console.log(`${chalk.gray('   Paused at:')}  ${rotation.paused_at || '(unknown)'}`);
+    if (rotation.pause_reason) {
+      console.log(`${chalk.gray('   Reason:')}     ${rotation.pause_reason}`);
+    }
+    console.log(chalk.yellow('   Use `ada resume` to continue dispatch cycles.'));
+    console.log();
+  }
+
   // Rotation summary
   const currentRoleStr = currentRole
     ? `${currentRole.emoji} ${currentRole.name} (${currentRole.title})`

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -1,0 +1,100 @@
+/**
+ * `ada stop` — Graceful shutdown command.
+ *
+ * Signals ADA to stop after the current cycle completes.
+ * Use --force for immediate termination.
+ */
+
+import { Command } from 'commander';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+/** PID file location for watch mode signaling */
+const PID_FILE = '.ada-watch.pid';
+
+/**
+ * Check if a process is running.
+ */
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Send a signal to a process.
+ */
+function sendSignal(pid: number, signal: NodeJS.Signals): boolean {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export const stopCommand = new Command('stop')
+  .description('Graceful stop — finish current cycle, then exit')
+  .option('-f, --force', 'Immediate termination (SIGKILL)')
+  .option('-d, --dir <path>', 'Agents directory (default: "agents/")', 'agents')
+  .action(
+    async (options: {
+      force?: boolean;
+      dir: string;
+    }) => {
+      const cwd = process.cwd();
+      const pidPath = path.join(cwd, options.dir, PID_FILE);
+
+      console.log(options.force ? '🛑 ADA Force Stop' : '⏹️  ADA Graceful Stop');
+      console.log();
+
+      try {
+        // Check for PID file (watch mode)
+        const pidData = await fs.readFile(pidPath, 'utf-8').catch(() => null);
+
+        if (pidData) {
+          const pid = parseInt(pidData.trim(), 10);
+
+          if (isNaN(pid)) {
+            console.log('⚠️  Invalid PID file. Cleaning up...');
+            await fs.unlink(pidPath).catch(() => {});
+            return;
+          }
+
+          const running = isProcessRunning(pid);
+
+          if (running) {
+            const signal: NodeJS.Signals = options.force ? 'SIGKILL' : 'SIGTERM';
+            const success = sendSignal(pid, signal);
+
+            if (success) {
+              console.log(`✅ Signal sent to ADA process (PID: ${pid})`);
+              console.log(
+                options.force
+                  ? '   Process terminated immediately.'
+                  : '   Process will exit after current cycle completes.'
+              );
+            } else {
+              console.log(`❌ Failed to signal process ${pid}`);
+            }
+          } else {
+            console.log('ℹ️  No active ADA watch mode found.');
+            console.log('   PID file exists but process is not running.');
+            console.log('   Cleaning up stale PID file...');
+            await fs.unlink(pidPath).catch(() => {});
+          }
+        } else {
+          console.log('ℹ️  No active ADA watch mode detected.');
+          console.log('');
+          console.log('   If ADA is running via external scheduler (cron, OpenClaw),');
+          console.log('   use `ada pause` to prevent future cycles from executing.');
+        }
+      } catch (err) {
+        console.error('❌ Stop failed:', (err as Error).message);
+        process.exit(1);
+      }
+    }
+  );

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,9 @@ import { runCommand } from './commands/run.js';
 import { statusCommand } from './commands/status.js';
 import { configCommand } from './commands/config.js';
 import { memoryCommand } from './commands/memory.js';
+import { stopCommand } from './commands/stop.js';
+import { pauseCommand } from './commands/pause.js';
+import { resumeCommand } from './commands/resume.js';
 
 const program = new Command();
 
@@ -31,5 +34,8 @@ program.addCommand(runCommand);
 program.addCommand(statusCommand);
 program.addCommand(configCommand);
 program.addCommand(memoryCommand);
+program.addCommand(stopCommand);
+program.addCommand(pauseCommand);
+program.addCommand(resumeCommand);
 
 program.parse();

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -112,6 +112,12 @@ export interface RotationState {
   cycle_count: number;
   /** Recent history (last N entries) */
   history: RotationHistoryEntry[];
+  /** Whether dispatch is paused */
+  paused?: boolean;
+  /** ISO timestamp when pause was set */
+  paused_at?: string;
+  /** Reason for pausing (optional) */
+  pause_reason?: string;
 }
 
 // ─── Memory Bank Types ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements Issue #70 — graceful shutdown control for ADA dispatch.

## New Commands

### `ada stop`
- **Purpose:** Signal watch mode to stop after current cycle completes
- **Options:**
  - `--force` / `-f`: Immediate termination (SIGKILL)
  - `--dir <path>`: Custom agents directory

### `ada pause`
- **Purpose:** Set paused flag in rotation.json to prevent future cycles
- **Options:**
  - `--reason <text>` / `-r`: Custom pause reason
  - `--no-commit`: Skip git commit
  - `--dir <path>`: Custom agents directory

### `ada resume`
- **Purpose:** Clear paused flag to allow dispatch cycles to run again
- **Options:**
  - `--no-commit`: Skip git commit
  - `--dir <path>`: Custom agents directory

## Changes

| File | Change |
|------|--------|
| `packages/core/src/types.ts` | Add `paused`, `paused_at`, `pause_reason` to RotationState |
| `packages/cli/src/commands/stop.ts` | New command for watch mode signaling |
| `packages/cli/src/commands/pause.ts` | New command to pause dispatch |
| `packages/cli/src/commands/resume.ts` | New command to resume dispatch |
| `packages/cli/src/commands/run.ts` | Check paused state before dispatch |
| `packages/cli/src/commands/status.ts` | Show paused state in status output |
| `packages/cli/src/index.ts` | Register new commands |

## Tests

- `packages/cli/src/commands/__tests__/control.test.ts`: Command structure tests (13 tests)
- All existing tests pass (144 CLI + 299 core = 443 total)

## Acceptance Criteria

From Issue #70:
- [x] `ada stop` signals graceful shutdown to watch mode
- [x] `ada stop --force` available for emergency
- [x] `ada pause` sets paused flag in rotation.json
- [x] `ada pause --reason` allows custom reason
- [x] `ada resume` clears paused state
- [x] `ada run` checks paused flag before dispatch
- [x] `ada status` shows paused state when applicable
- [x] All commands have help text (`--help`)
- [x] Tests for new commands

---
*⚙️ The Builder | Cycle 123*

Relates to #70, #63