### PR TITLE
feat(core): Phase 2 — Latency Timer for Agent Observability

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -126,12 +126,14 @@ export {
   getRelativeTime,
 } from './memory-stats.js';
 
-// Observability (Phase 1 — Token Counter)
+// Observability (Phase 1 — Token Counter, Phase 2 — Latency Timer)
 export type {
   TokenUsage,
   TokenCost,
   ModelPricing,
   DispatchPhase,
+  PhaseLatency,
+  PhaseLatencyStats,
   CycleMetrics,
   AggregatedMetrics,
   MetricsState,
@@ -153,6 +155,8 @@ export {
   createMetricsManager,
   formatCost,
   formatTokens,
+  formatDuration,
+  calculateEfficiency,
 } from './observability.js';
 
 // Memory Importance Tracking (Phase 3.1)


### PR DESCRIPTION
## Summary

Extends the observability system (Issue #69) with per-phase timing for performance analysis. This is Phase 2 of the observability work, building on the token counter foundation from Cycle 129.

## New Features

### Types
- `PhaseLatency` — Start/end timestamps and duration per phase
- `PhaseLatencyStats` — Count/total/avg/min/max stats across cycles

### CycleTracker Methods
- `startPhase(phase)` / `endPhase()` — Manual phase timing
- `timePhase(phase, fn)` — Automatic async timing with callback
- `timePhaseSync(phase, fn)` — Automatic sync timing with callback
- `isPhaseActive()` / `getActivePhase()` — Timer state inspection

### CycleMetrics
- `latency?: Partial<Record<DispatchPhase, PhaseLatency>>` — Per-phase timing data

### AggregatedMetrics
- `avgDurationMs` — Average cycle duration
- `phaseLatency?: Partial<Record<DispatchPhase, PhaseLatencyStats>>` — Cross-cycle stats

### Utilities
- `formatDuration(ms)` — Human-readable duration ("234ms", "12.4s", "2m 34s")
- `calculateEfficiency(tokens, durationMs)` — Tokens-per-second for optimization

## Design Decisions

1. **Opt-in** — Phase timing is optional, backwards compatible
2. **Single active timer** — Prevents overlapping phase measurements
3. **Auto-end on finalize** — Safety net for forgotten endPhase() calls
4. **Comprehensive stats** — Min/max/avg/total per phase for debugging

## Testing

- 21 new tests added (529 total, up from 508)
- All tests passing
- TypeScript strict mode compliant

## Related

- Issue #69: Agent Observability
- Cycle 129: Phase 1 Token Counter (Frontier)
- Cycle 130: Product CLI Spec
- Cycle 133-134: CLI Implementation (Engineering/Ops)

---

🌌 Frontier | Cycle 139