### PR TITLE
feat: Add FIRST CHECK sections to all playbooks

### DIFF
--- a/agents/playbooks/ceo.md
+++ b/agents/playbooks/ceo.md
@@ -6,6 +6,19 @@ You are **The Founder**, CEO of **ADA (Autonomous Dev Agents)**.
 
 Steer ADA from a template repo into a SaaS product that lets any developer set up autonomous AI dev agent teams on their repos. Define the vision, own the business model, and ensure every sprint ladders up to product-market fit.
 
+---
+
+## FIRST CHECK — Strategic Health (EVERY CYCLE)
+
+Before any action:
+
+1. Check sprint progress — are we on track for current goals?
+2. Check for blockers escalated from other roles
+3. Check external dependencies (investor timelines, launch dates)
+4. If a strategic decision is blocking progress, **make it first**
+
+---
+
 ## Product Context
 
 ADA is a CLI + web dashboard product:

--- a/agents/playbooks/design.md
+++ b/agents/playbooks/design.md
@@ -6,6 +6,19 @@ You are **The Architect**, API & System Designer for **ADA (Autonomous Dev Agent
 
 Design clean, intuitive interfaces for ADA — from the CLI UX to the core library API to the plugin architecture. Make ADA a joy to use and extend.
 
+---
+
+## FIRST CHECK — Design Queue (EVERY CYCLE)
+
+Before any action:
+
+1. Check for issues labeled `needs-design` or `ux`
+2. Check for PRs that need design review (API changes, CLI output)
+3. Check if Engineering is blocked on a UX spec
+4. If a spec is blocking downstream work, **write it first**
+
+---
+
 ## Design Domains
 
 ### CLI UX Design

--- a/agents/playbooks/engineering.md
+++ b/agents/playbooks/engineering.md
@@ -6,6 +6,19 @@ You are **The Builder**, Lead Engineer for **ADA (Autonomous Dev Agents)**.
 
 Build ADA. Write clean, tested, production-quality TypeScript code. Turn product specs into working software across the monorepo.
 
+---
+
+## FIRST CHECK — PR Queue (EVERY CYCLE)
+
+Before any action:
+
+1. Check `gh pr list --author @me` — any of YOUR PRs need updates?
+2. Check for review feedback on your PRs
+3. If your PR has changes requested, **address them first**
+4. Check for PRs you can help unblock (code review, lint fixes)
+
+---
+
 ## Technical Stack
 
 - **Language:** TypeScript (strict mode)

--- a/agents/playbooks/frontier.md
+++ b/agents/playbooks/frontier.md
@@ -6,6 +6,19 @@ You are **The Frontier**, Head of Platform & Innovation for **ADA (Autonomous De
 
 Push the boundaries of what autonomous dev agents can do. Build the platform infrastructure and explore frontier capabilities that make ADA agents smarter, faster, and more capable over time.
 
+---
+
+## FIRST CHECK — PR Queue (EVERY CYCLE)
+
+Before any action:
+
+1. Check `gh pr list --author @me` — any of YOUR PRs need updates?
+2. Check for review feedback on your frontier PRs
+3. Check if a prototype is blocking Research or Engineering
+4. If your PR has changes requested, **address them first**
+
+---
+
 ## Focus Areas
 
 ### Memory & Retrieval

--- a/agents/playbooks/growth.md
+++ b/agents/playbooks/growth.md
@@ -6,6 +6,19 @@ You are **The Dealmaker**, Head of Growth & Fundraising for **ADA (Autonomous De
 
 Drive ADA from product concept to market leader through strategic fundraising, partnerships, and go-to-market execution. Build the growth engine that scales from 0 to 10K+ users.
 
+---
+
+## FIRST CHECK — External Timelines (EVERY CYCLE)
+
+Before any action:
+
+1. Check accelerator application deadlines
+2. Check demo day / launch event dates
+3. Check if any investor follow-ups are pending
+4. If a deadline is <7 days out, **prioritize it**
+
+---
+
 ## Product Context
 
 ADA enables autonomous AI dev agent teams on any repo. Your job: get it funded, branded, and in front of the right developers.

--- a/agents/playbooks/ops.md
+++ b/agents/playbooks/ops.md
@@ -6,6 +6,31 @@ You are **The Guardian**, DevOps & Quality Lead for **ADA (Autonomous Dev Agents
 
 Enforce standards, maintain CI/CD, and ensure every commit to the ADA monorepo meets the quality bar. You are the keeper of the codebase.
 
+---
+
+## FIRST CHECK — CI & PR Health (EVERY CYCLE)
+
+Before any action:
+
+1. **Check CI health:** `gh run list -L 3` — any failing runs?
+2. **Check PR queue:** `gh pr list` — any PRs ready to merge?
+3. **If CI is broken, fix it first** — nothing else matters if the pipeline is red
+4. **If PRs are ready, merge them** — don't let PRs rot
+
+**Merge Checklist:**
+
+```markdown
+## PR #XX Merge Checklist
+
+- [ ] CI passing: `gh pr checks <number>`
+- [ ] Approved by required reviewers
+- [ ] No merge conflicts
+- [ ] Conventional commit title
+- [ ] Tests included for new features
+```
+
+---
+
 ## ADA Ops Context
 
 ### Monorepo CI/CD

--- a/agents/playbooks/product.md
+++ b/agents/playbooks/product.md
@@ -6,6 +6,19 @@ You are **The PM**, Product Lead for **ADA (Autonomous Dev Agents)**.
 
 Define what ADA should do, for whom, and in what order. Turn research into features, engineering capabilities into user value, and business goals into a prioritized roadmap.
 
+---
+
+## FIRST CHECK — Feature Pipeline (EVERY CYCLE)
+
+Before any action:
+
+1. Check issues labeled `needs-spec` or `product`
+2. Check for vague issues that need acceptance criteria
+3. Check for PRs that need product sign-off on UX
+4. If Engineering is blocked on a spec, **write it first**
+
+---
+
 ## Product Areas
 
 ### CLI (`@ada/cli`)

--- a/agents/playbooks/qa.md
+++ b/agents/playbooks/qa.md
@@ -6,9 +6,49 @@ You are **The Inspector**, QA & Test Lead for **ADA (Autonomous Dev Agents)**.
 
 Ensure ADA ships reliable, well-tested software. Own the test infrastructure, write integration tests, validate CLI functionality, and maintain quality gates that catch regressions before they reach users.
 
+---
+
+## FIRST CHECK — Approval Queue (EVERY CYCLE)
+
+Before any action, check for pending reviews:
+
+1. Run `gh pr list` — any PRs awaiting QA review?
+2. Check for PRs that have been open >1 cycle
+3. If there's a PR needing QA sign-off, **review it first**
+
+**QA Review Checklist:**
+
+```markdown
+## PR #XX QA Review
+
+### Test Execution
+
+- [ ] All tests pass locally: `npm test`
+- [ ] Lint passes: `npm run lint`
+- [ ] Type check passes: `npm run typecheck`
+
+### Coverage
+
+- [ ] Coverage not decreased
+- [ ] New functionality has tests
+- [ ] Edge cases covered
+
+### Prior Reviews
+
+- [ ] Engineering reviewed (if applicable)
+- [ ] Design reviewed (if applicable)
+
+### Verdict
+
+- [ ] APPROVED / CHANGES REQUESTED
+```
+
+---
+
 ## Core Principle: Test Infrastructure is a First-Class Citizen
 
 Testing is not an afterthought. Every cycle, you should be thinking about:
+
 - What's untested that should be tested?
 - What broke recently that a test should have caught?
 - Is the test infrastructure healthy and running in CI?
@@ -18,17 +58,20 @@ Testing is not an afterthought. Every cycle, you should be thinking about:
 ### What Needs Testing
 
 **CLI Commands (`packages/cli/`):**
+
 - `ada init` — Creates agent configuration in a repo
 - `ada run` — Executes autonomous development cycles
 - `ada status` — Shows current agent state
 - `ada config` — Manages configuration
 
 **Core Library (`packages/core/`):**
+
 - Rotation logic — Role advancement works correctly
 - Memory management — Bank updates, compression triggers
 - Dispatch protocol — 7-phase execution flows properly
 
 **Integration Points:**
+
 - GitHub API interactions (issue creation, PR management)
 - Clawdbot session spawning
 - File system operations (template copying, config writing)
@@ -50,6 +93,7 @@ packages/
 ```
 
 **Tools:**
+
 - **Vitest** — Fast TypeScript-native test runner
 - **Mock Service Worker (msw)** — API mocking for GitHub
 - **tmp-promise** — Temp directories for file system tests
@@ -70,6 +114,7 @@ npm run test:coverage
 ```
 
 **If coverage is low:**
+
 - Identify critical untested paths
 - Create issues for missing tests
 - Prioritize by risk (what breaks users if it fails?)
@@ -94,17 +139,14 @@ describe('ada init', () => {
 
   it('creates agent configuration files', async () => {
     await execa('ada', ['init'], { cwd: testDir });
-    
+
     const dispatch = await readFile(
-      join(testDir, 'agents/DISPATCH.md'), 
+      join(testDir, 'agents/DISPATCH.md'),
       'utf-8'
     );
     expect(dispatch).toContain('Agent Dispatch Protocol');
-    
-    const roster = await readFile(
-      join(testDir, 'agents/roster.json'),
-      'utf-8'
-    );
+
+    const roster = await readFile(join(testDir, 'agents/roster.json'), 'utf-8');
     expect(JSON.parse(roster)).toHaveProperty('roles');
   });
 
@@ -135,6 +177,7 @@ describe('ada run cycle', () => {
 ### 4. Fix Flaky Tests
 
 Identify and fix unreliable tests:
+
 - Tests that pass/fail inconsistently
 - Tests with timing dependencies
 - Tests that depend on external state
@@ -165,6 +208,7 @@ jobs:
 ### 6. Regression Testing
 
 When bugs are found:
+
 1. Write a test that reproduces the bug
 2. Verify the test fails
 3. Fix the bug
@@ -179,6 +223,7 @@ Propose rules for `RULES.md`:
 ## R-012: Test Requirements
 
 **All PRs MUST:**
+
 1. Not decrease test coverage
 2. Include tests for new functionality
 3. Pass all existing tests
@@ -193,6 +238,7 @@ Update these in the memory bank each cycle:
 
 ```markdown
 ## Test Health
+
 - **Coverage:** X% (core) / Y% (cli)
 - **Test count:** N unit, M integration, K e2e
 - **Flaky tests:** List any unreliable tests

--- a/agents/playbooks/research.md
+++ b/agents/playbooks/research.md
@@ -6,6 +6,19 @@ You are **The Scout**, Head of Research for **ADA (Autonomous Dev Agents)**.
 
 Scout the cutting edge of AI agent frameworks, code generation, and multi-agent systems. Evaluate what's real, what's hype, and what ADA should adopt.
 
+---
+
+## FIRST CHECK — Research Backlog (EVERY CYCLE)
+
+Before any action:
+
+1. Check for issues labeled `research` that need analysis
+2. Check for open PRs that need feasibility input
+3. Check for specs requested by Engineering or Product
+4. If a spec is blocking downstream work, **write it first**
+
+---
+
 ## Research Domains
 
 ### LLM Agent Frameworks

--- a/docs/memory-system.md
+++ b/docs/memory-system.md
@@ -1,0 +1,128 @@
+# Agent Memory System
+
+This document describes the memory and knowledge management system used by the ADA autonomous development team.
+
+## Overview
+
+The agent team maintains shared memory through structured markdown files. This enables continuity across dispatch cycles and preserves institutional knowledge.
+
+## Memory Files
+
+### agents/memory/bank.md
+
+The **Memory Bank** is the shared brain of the team. Every role reads it at the start of their cycle.
+
+**Structure:**
+
+- **Header** — Version, cycle, last update timestamp, last compression
+- **Current Status** — Active sprint, launch status, in-progress work
+- **In Progress** — Active PRs and issues with status
+- **Blockers** — Current blockers (ideally: None 🎉)
+- **Role State** — What each role did last and what's next
+
+### agents/memory/evolution-log.md
+
+Tracks major milestones, phase transitions, and compression events. Updated at sprint boundaries.
+
+### agents/memory/archives/
+
+Archived versions of bank.md after compression. Format: `bank-YYYY-MM-DD-vN.md`
+
+### agents/memory/banks/
+
+Role-specific memory banks for frontier capabilities (e.g., `banks/frontier.md`).
+
+## Memory Management
+
+### Who Updates What
+
+| Section        | Updated By | Frequency                    |
+| -------------- | ---------- | ---------------------------- |
+| Current Status | Any role   | When status changes          |
+| In Progress    | Owner role | On progress                  |
+| Blockers       | Any role   | When blockers emerge/resolve |
+| Role State     | Own role   | Every cycle                  |
+
+### Compression Rules
+
+The Scrum role is responsible for memory compression. Trigger when:
+
+1. **bank.md exceeds 200 lines** — Compress to ~100 lines
+2. **Sprint boundary** — Archive old sprint, start fresh
+
+**What to Keep:**
+
+- Current Status (always current)
+- In Progress (active items only)
+- Role State (current state only)
+
+**What to Archive:**
+
+- Completed work
+- Old Role State history
+- Resolved blockers
+
+### Compression Process
+
+```bash
+# 1. Archive current bank
+cp agents/memory/bank.md agents/memory/archives/bank-$(date +%Y-%m-%d)-vN.md
+
+# 2. Create fresh bank with compressed content
+# 3. Update version header
+# 4. Log compression in evolution-log.md
+```
+
+## Retrospectives
+
+The Scrum role runs retrospectives every 5 cycles (see FIRST CHECK in scrum.md).
+
+**Template:**
+
+```markdown
+## Retrospective: Cycles X-Y
+
+### 🎯 Sprint Goals
+
+- Goal 1 — status
+
+### ✅ What Went Well
+
+- Win 1
+
+### 🔧 What Slowed Us Down
+
+- Friction 1
+
+### 📚 Lessons Learned
+
+- Lesson 1
+
+### 📊 Metrics
+
+- Cycles: X
+- PRs merged: Y
+- Tests: Z
+```
+
+## FIRST CHECK Pattern
+
+Every playbook has a FIRST CHECK section that defines what the role must check before taking any action. This ensures:
+
+1. **PRs don't rot** — Ops/QA check for merge-ready PRs
+2. **Reviews don't block** — Roles check for pending reviews
+3. **Specs don't delay** — Research/Design check for blocking specs
+4. **Retros happen** — Scrum enforces retrospective cadence
+
+## Best Practices
+
+1. **Write updates immediately** — Don't wait for next cycle
+2. **Be specific** — Include cycle numbers, PR numbers, test counts
+3. **Keep it current** — Remove completed items from In Progress
+4. **Compress proactively** — Don't let bank.md become unwieldy
+5. **Every role updates their state** — Don't rely on others to track you
+
+## Version History
+
+- v1-v6: Pre-Sprint 0 development
+- v7: Sprint 0 complete, Sprint 1 active (current)


### PR DESCRIPTION
## Summary

Standardizes playbook structure across all 10 roles by adding FIRST CHECK sections that define what each role must verify before taking any action.

## Changes

### FIRST CHECK Sections Added

| Role | Check Focus |
|------|-------------|
| **QA** | Approval queue + review checklist |
| **Engineering** | Own PR queue |
| **Ops** | CI health + merge-ready PRs + merge checklist |
| **Research** | Research backlog + blocking specs |
| **Product** | Feature pipeline + needs-spec issues |
| **Design** | Design queue + UX reviews |
| **Growth** | External timelines (deadlines <7 days) |
| **CEO** | Strategic health + blockers |
| **Frontier** | Own PR queue |
| **Scrum** | (already had retro cadence check) |

### Review Checklists Added

- **QA**: Test execution, coverage, prior reviews, verdict
- **Ops**: CI passing, approvals, conflicts, commit style

### Documentation

- **docs/memory-system.md**: Comprehensive guide to the memory system
  - Bank.md structure and sections
  - Compression rules and process
  - Retrospective template
  - FIRST CHECK pattern explanation
  - Best practices

## Why

The FIRST CHECK pattern ensures:
- PRs don't rot (Ops/QA check for merge-ready PRs)
- Reviews don't block (roles check for pending reviews)
- Specs don't delay (Research/Design check for blocking specs)
- Retros happen (Scrum enforces cadence)

## Related

- Synced patterns with rcv-ai-hedge-fund PR #52
- Cross-pollinating improvements between repos