### PR TITLE
feat(core): implement Reflexion Phase 1a — reflection types and utilities

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,9 +21,25 @@ export type {
   MemoryBank,
   DispatchResult,
   AdaConfig,
+  // Reflexion types (Issue #108 — Phase 1a)
+  ReflectionOutcome,
+  Reflection,
 } from './types.js';
 
 export { DEFAULT_CONFIG } from './types.js';
+
+// Reflection (Issue #108 — Reflexion Pattern Phase 1a)
+export {
+  MAX_SHORT_FIELD_LENGTH,
+  MAX_LESSON_LENGTH,
+  DEFAULT_REFLECTION_COUNT,
+  generateReflectionPrompt,
+  parseReflection,
+  getRecentReflections,
+  formatReflectionsForContext,
+  isValidReflection,
+  createEmptyReflection,
+} from './reflection.js';
 
 // Rotation
 export {

--- a/packages/core/src/reflection.ts
+++ b/packages/core/src/reflection.ts
@@ -1,0 +1,264 @@
+/**
+ * @ada/core — Reflexion utilities
+ *
+ * Implements lightweight self-critique for ADA dispatch cycles.
+ * Based on: Shinn et al. (2023) — "Reflexion: Language Agents with Verbal Reinforcement Learning"
+ *
+ * Phase 1a of the Recursive LM roadmap (Issue #108).
+ *
+ * @see docs/research/reflexion-integration-spec.md
+ */
+
+import type {
+  Reflection,
+  ReflectionOutcome,
+  RotationHistoryEntry,
+  RoleId,
+} from './types.js';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/** Maximum length for whatWorked and whatToImprove fields */
+export const MAX_SHORT_FIELD_LENGTH = 100;
+
+/** Maximum length for lessonLearned field */
+export const MAX_LESSON_LENGTH = 150;
+
+/** Default number of recent reflections to retrieve */
+export const DEFAULT_REFLECTION_COUNT = 3;
+
+// ─── Prompt Generation ───────────────────────────────────────────────────────
+
+/**
+ * Generate the prompt for post-action reflection.
+ *
+ * This should be appended to the LLM context after an action is taken,
+ * asking the agent to self-critique before the cycle ends.
+ *
+ * @param actionSummary - Brief description of the action just completed
+ * @returns Markdown prompt for the LLM
+ */
+export function generateReflectionPrompt(actionSummary: string): string {
+  return `## Post-Action Reflection
+
+You just completed: ${actionSummary}
+
+Reflect briefly on this action:
+
+1. **Outcome:** Was this successful, partially successful, blocked, or unknown?
+2. **What worked:** What aspect of your approach was effective? (1 sentence, max 100 chars)
+3. **What to improve:** What would you do differently next time? (1 sentence, max 100 chars)
+4. **Lesson learned:** Any insight worth remembering? (optional, 1 sentence, max 150 chars)
+
+Respond in this exact JSON format:
+\`\`\`json
+{
+  "outcome": "success" | "partial" | "blocked" | "unknown",
+  "whatWorked": "string or null",
+  "whatToImprove": "string or null",
+  "lessonLearned": "string or null"
+}
+\`\`\`
+
+Keep responses concise — this adds ~50-100 tokens per cycle.`;
+}
+
+// ─── Parsing ─────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a reflection from LLM output.
+ *
+ * Attempts to extract a JSON block from the response. If parsing fails,
+ * returns a fallback reflection with outcome 'unknown' (graceful degradation).
+ *
+ * @param llmOutput - Raw LLM response containing the reflection JSON
+ * @returns Parsed and validated Reflection object
+ */
+export function parseReflection(llmOutput: string): Reflection {
+  try {
+    // Try to extract JSON from code block
+    const jsonMatch = llmOutput.match(/```(?:json)?\s*([\s\S]*?)```/);
+    const jsonStr = jsonMatch?.[1]?.trim() ?? llmOutput.trim();
+
+    const parsed = JSON.parse(jsonStr) as Record<string, unknown>;
+
+    // Validate and sanitize outcome
+    const validOutcomes: ReflectionOutcome[] = [
+      'success',
+      'partial',
+      'blocked',
+      'unknown',
+    ];
+    const outcome: ReflectionOutcome = validOutcomes.includes(
+      parsed.outcome as ReflectionOutcome
+    )
+      ? (parsed.outcome as ReflectionOutcome)
+      : 'unknown';
+
+    // Truncate fields to max lengths
+    const whatWorked = truncateField(parsed.whatWorked, MAX_SHORT_FIELD_LENGTH);
+    const whatToImprove = truncateField(
+      parsed.whatToImprove,
+      MAX_SHORT_FIELD_LENGTH
+    );
+    const lessonLearned = truncateField(parsed.lessonLearned, MAX_LESSON_LENGTH);
+
+    return {
+      outcome,
+      ...(whatWorked && { whatWorked }),
+      ...(whatToImprove && { whatToImprove }),
+      ...(lessonLearned && { lessonLearned }),
+    };
+  } catch {
+    // Graceful degradation: don't block dispatch for reflection parsing
+    return { outcome: 'unknown' };
+  }
+}
+
+/**
+ * Truncate a field to a maximum length.
+ *
+ * @param value - The value to truncate (may be undefined/null)
+ * @param maxLength - Maximum allowed length
+ * @returns Truncated string or undefined
+ */
+function truncateField(
+  value: unknown,
+  maxLength: number
+): string | undefined {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, maxLength - 3)}...`;
+}
+
+// ─── Retrieval ───────────────────────────────────────────────────────────────
+
+/**
+ * Get recent reflections for a specific role from history.
+ *
+ * Filters history to entries for the given role that have reflections,
+ * returns the most recent N entries in reverse chronological order.
+ *
+ * @param history - Rotation history entries
+ * @param role - Role ID to filter by
+ * @param count - Number of reflections to retrieve (default: 3)
+ * @returns Array of reflections with cycle metadata
+ */
+export function getRecentReflections(
+  history: readonly RotationHistoryEntry[],
+  role: RoleId,
+  count: number = DEFAULT_REFLECTION_COUNT
+): ReadonlyArray<{
+  readonly cycle: number;
+  readonly timestamp: string;
+  readonly action?: string;
+  readonly reflection: Reflection;
+}> {
+  return history
+    .filter((h): h is RotationHistoryEntry & { reflection: Reflection } =>
+      h.role === role && h.reflection !== undefined
+    )
+    .slice(-count)
+    .reverse()
+    .map((h) => ({
+      cycle: h.cycle,
+      timestamp: h.timestamp,
+      ...(h.action !== undefined && { action: h.action }),
+      reflection: h.reflection,
+    }));
+}
+
+/**
+ * Format recent reflections for injection into dispatch context.
+ *
+ * Produces a markdown block suitable for appending to playbook context.
+ *
+ * @param role - Role name for the header
+ * @param reflections - Recent reflections from getRecentReflections()
+ * @returns Formatted markdown string
+ */
+export function formatReflectionsForContext(
+  role: string,
+  reflections: ReadonlyArray<{
+    readonly cycle: number;
+    readonly reflection: Reflection;
+  }>
+): string {
+  if (reflections.length === 0) {
+    return '';
+  }
+
+  const lines: string[] = [
+    `## Recent Reflections (${role} — last ${reflections.length} cycles)`,
+    '',
+  ];
+
+  for (const { cycle, reflection } of reflections) {
+    lines.push(`### Cycle ${cycle}`);
+    lines.push(`- **Outcome:** ${reflection.outcome}`);
+    if (reflection.whatWorked) {
+      lines.push(`- **Worked:** ${reflection.whatWorked}`);
+    }
+    if (reflection.whatToImprove) {
+      lines.push(`- **Improve:** ${reflection.whatToImprove}`);
+    }
+    if (reflection.lessonLearned) {
+      lines.push(`- **Lesson:** ${reflection.lessonLearned}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+/**
+ * Validate a reflection object.
+ *
+ * @param reflection - Reflection to validate
+ * @returns True if valid, false otherwise
+ */
+export function isValidReflection(reflection: unknown): reflection is Reflection {
+  if (typeof reflection !== 'object' || reflection === null) {
+    return false;
+  }
+
+  const r = reflection as Record<string, unknown>;
+
+  // outcome is required
+  const validOutcomes = ['success', 'partial', 'blocked', 'unknown'];
+  if (typeof r.outcome !== 'string' || !validOutcomes.includes(r.outcome)) {
+    return false;
+  }
+
+  // Optional fields must be strings if present
+  if (r.whatWorked !== undefined && typeof r.whatWorked !== 'string') {
+    return false;
+  }
+  if (r.whatToImprove !== undefined && typeof r.whatToImprove !== 'string') {
+    return false;
+  }
+  if (r.lessonLearned !== undefined && typeof r.lessonLearned !== 'string') {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Create an empty reflection for failed or skipped cycles.
+ *
+ * @param outcome - The outcome to set (default: 'unknown')
+ * @returns A minimal reflection object
+ */
+export function createEmptyReflection(
+  outcome: ReflectionOutcome = 'unknown'
+): Reflection {
+  return { outcome };
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -88,6 +88,26 @@ export interface Roster {
 
 // ─── Rotation State ──────────────────────────────────────────────────────────
 
+// ─── Reflection Types (Reflexion Pattern) ───────────────────────────────────
+
+/** Outcome of an action for reflection tracking */
+export type ReflectionOutcome = 'success' | 'partial' | 'blocked' | 'unknown';
+
+/**
+ * Reflexion-style self-critique attached to a dispatch cycle.
+ * See: Shinn et al. (2023) — "Reflexion: Language Agents with Verbal Reinforcement Learning"
+ */
+export interface Reflection {
+  /** How did the action turn out? */
+  readonly outcome: ReflectionOutcome;
+  /** What aspect of the approach was effective? (max 100 chars) */
+  readonly whatWorked?: string;
+  /** What would you do differently next time? (max 100 chars) */
+  readonly whatToImprove?: string;
+  /** Any insight worth remembering? (max 150 chars) */
+  readonly lessonLearned?: string;
+}
+
 /** A single entry in the rotation history */
 export interface RotationHistoryEntry {
   /** Role that acted */
@@ -98,6 +118,8 @@ export interface RotationHistoryEntry {
   readonly cycle: number;
   /** Brief description of the action taken */
   readonly action?: string;
+  /** Self-critique reflection on the action (Phase 1a: Reflexion) */
+  readonly reflection?: Reflection;
 }
 
 /** Current rotation state — tracks where we are in the cycle */

--- a/packages/core/tests/unit/reflection.test.ts
+++ b/packages/core/tests/unit/reflection.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests for the Reflexion module (Issue #108 — Phase 1a)
+ *
+ * Verifies reflection prompt generation, parsing, retrieval, and formatting.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  generateReflectionPrompt,
+  parseReflection,
+  getRecentReflections,
+  formatReflectionsForContext,
+  isValidReflection,
+  createEmptyReflection,
+  MAX_SHORT_FIELD_LENGTH,
+  MAX_LESSON_LENGTH,
+  DEFAULT_REFLECTION_COUNT,
+} from '../../src/reflection.js';
+import type { RotationHistoryEntry } from '../../src/types.js';
+
+// ─── Constants Tests ─────────────────────────────────────────────────────────
+
+describe('Constants', () => {
+  it('should have correct max lengths', () => {
+    expect(MAX_SHORT_FIELD_LENGTH).toBe(100);
+    expect(MAX_LESSON_LENGTH).toBe(150);
+    expect(DEFAULT_REFLECTION_COUNT).toBe(3);
+  });
+});
+
+// ─── Prompt Generation Tests ─────────────────────────────────────────────────
+
+describe('generateReflectionPrompt', () => {
+  it('should include the action summary', () => {
+    const prompt = generateReflectionPrompt('Created issue #42');
+    expect(prompt).toContain('Created issue #42');
+  });
+
+  it('should request all reflection fields', () => {
+    const prompt = generateReflectionPrompt('Test action');
+    expect(prompt).toContain('Outcome');
+    expect(prompt).toContain('What worked');
+    expect(prompt).toContain('What to improve');
+    expect(prompt).toContain('Lesson learned');
+  });
+
+  it('should include JSON format example', () => {
+    const prompt = generateReflectionPrompt('Test action');
+    expect(prompt).toContain('"outcome"');
+    expect(prompt).toContain('"whatWorked"');
+    expect(prompt).toContain('"whatToImprove"');
+    expect(prompt).toContain('"lessonLearned"');
+  });
+});
+
+// ─── Parsing Tests ───────────────────────────────────────────────────────────
+
+describe('parseReflection', () => {
+  it('should parse a valid JSON block', () => {
+    const llmOutput = `
+Here's my reflection:
+\`\`\`json
+{
+  "outcome": "success",
+  "whatWorked": "Building on prior analysis",
+  "whatToImprove": "Could have included more examples",
+  "lessonLearned": "Specs are more actionable with concrete schemas"
+}
+\`\`\`
+    `;
+
+    const result = parseReflection(llmOutput);
+
+    expect(result.outcome).toBe('success');
+    expect(result.whatWorked).toBe('Building on prior analysis');
+    expect(result.whatToImprove).toBe('Could have included more examples');
+    expect(result.lessonLearned).toBe('Specs are more actionable with concrete schemas');
+  });
+
+  it('should parse all outcome types', () => {
+    const outcomes = ['success', 'partial', 'blocked', 'unknown'] as const;
+
+    for (const outcome of outcomes) {
+      const llmOutput = `\`\`\`json\n{"outcome": "${outcome}"}\n\`\`\``;
+      const result = parseReflection(llmOutput);
+      expect(result.outcome).toBe(outcome);
+    }
+  });
+
+  it('should default to unknown for invalid outcomes', () => {
+    const llmOutput = '```json\n{"outcome": "awesome"}\n```';
+    const result = parseReflection(llmOutput);
+    expect(result.outcome).toBe('unknown');
+  });
+
+  it('should truncate long fields', () => {
+    const longText = 'a'.repeat(200);
+    const llmOutput = `\`\`\`json\n{"outcome": "success", "whatWorked": "${longText}"}\n\`\`\``;
+
+    const result = parseReflection(llmOutput);
+
+    expect(result.whatWorked).toBeDefined();
+    expect(result.whatWorked?.length).toBe(MAX_SHORT_FIELD_LENGTH);
+    expect(result.whatWorked).toContain('...');
+  });
+
+  it('should handle missing optional fields', () => {
+    const llmOutput = '```json\n{"outcome": "partial"}\n```';
+    const result = parseReflection(llmOutput);
+
+    expect(result.outcome).toBe('partial');
+    expect(result.whatWorked).toBeUndefined();
+    expect(result.whatToImprove).toBeUndefined();
+    expect(result.lessonLearned).toBeUndefined();
+  });
+
+  it('should handle raw JSON without code block', () => {
+    const llmOutput = '{"outcome": "success", "whatWorked": "Direct approach"}';
+    const result = parseReflection(llmOutput);
+
+    expect(result.outcome).toBe('success');
+    expect(result.whatWorked).toBe('Direct approach');
+  });
+
+  it('should gracefully degrade on parse failure', () => {
+    const llmOutput = 'This is not JSON at all!';
+    const result = parseReflection(llmOutput);
+
+    expect(result.outcome).toBe('unknown');
+    expect(result.whatWorked).toBeUndefined();
+  });
+
+  it('should handle empty string fields', () => {
+    const llmOutput = '```json\n{"outcome": "success", "whatWorked": ""}\n```';
+    const result = parseReflection(llmOutput);
+
+    expect(result.outcome).toBe('success');
+    expect(result.whatWorked).toBeUndefined();
+  });
+});
+
+// ─── Retrieval Tests ─────────────────────────────────────────────────────────
+
+describe('getRecentReflections', () => {
+  const history: RotationHistoryEntry[] = [
+    { cycle: 1, role: 'engineering', timestamp: '2026-02-01T00:00:00Z', action: 'Action 1' },
+    { cycle: 2, role: 'engineering', timestamp: '2026-02-02T00:00:00Z', action: 'Action 2', reflection: { outcome: 'success', whatWorked: 'Test 1' } },
+    { cycle: 3, role: 'ops', timestamp: '2026-02-03T00:00:00Z', action: 'Action 3', reflection: { outcome: 'partial' } },
+    { cycle: 4, role: 'engineering', timestamp: '2026-02-04T00:00:00Z', action: 'Action 4', reflection: { outcome: 'success', whatWorked: 'Test 2' } },
+    { cycle: 5, role: 'engineering', timestamp: '2026-02-05T00:00:00Z', action: 'Action 5', reflection: { outcome: 'blocked', whatToImprove: 'Test 3' } },
+  ];
+
+  it('should filter by role', () => {
+    const result = getRecentReflections(history, 'engineering');
+
+    expect(result).toHaveLength(3);
+    expect(result.every((r) => r.reflection.outcome !== 'partial')).toBe(true);
+  });
+
+  it('should exclude entries without reflections', () => {
+    const result = getRecentReflections(history, 'engineering');
+
+    // Cycle 1 has no reflection
+    expect(result.find((r) => r.cycle === 1)).toBeUndefined();
+  });
+
+  it('should return in reverse chronological order', () => {
+    const result = getRecentReflections(history, 'engineering');
+
+    expect(result[0].cycle).toBe(5);
+    expect(result[1].cycle).toBe(4);
+    expect(result[2].cycle).toBe(2);
+  });
+
+  it('should respect count limit', () => {
+    const result = getRecentReflections(history, 'engineering', 2);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].cycle).toBe(5);
+    expect(result[1].cycle).toBe(4);
+  });
+
+  it('should return empty array for role with no reflections', () => {
+    const result = getRecentReflections(history, 'ceo');
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ─── Formatting Tests ────────────────────────────────────────────────────────
+
+describe('formatReflectionsForContext', () => {
+  const reflections = [
+    { cycle: 5, reflection: { outcome: 'success' as const, whatWorked: 'Clear spec', whatToImprove: 'More examples' } },
+    { cycle: 4, reflection: { outcome: 'partial' as const, lessonLearned: 'Always test first' } },
+  ];
+
+  it('should include role name in header', () => {
+    const result = formatReflectionsForContext('Engineering', reflections);
+    expect(result).toContain('## Recent Reflections (Engineering');
+  });
+
+  it('should include cycle numbers', () => {
+    const result = formatReflectionsForContext('Engineering', reflections);
+    expect(result).toContain('### Cycle 5');
+    expect(result).toContain('### Cycle 4');
+  });
+
+  it('should format all present fields', () => {
+    const result = formatReflectionsForContext('Engineering', reflections);
+
+    expect(result).toContain('**Outcome:** success');
+    expect(result).toContain('**Worked:** Clear spec');
+    expect(result).toContain('**Improve:** More examples');
+    expect(result).toContain('**Lesson:** Always test first');
+  });
+
+  it('should return empty string for no reflections', () => {
+    const result = formatReflectionsForContext('Engineering', []);
+    expect(result).toBe('');
+  });
+});
+
+// ─── Validation Tests ────────────────────────────────────────────────────────
+
+describe('isValidReflection', () => {
+  it('should accept valid reflections', () => {
+    expect(isValidReflection({ outcome: 'success' })).toBe(true);
+    expect(isValidReflection({ outcome: 'partial', whatWorked: 'Test' })).toBe(true);
+    expect(isValidReflection({ outcome: 'blocked', whatToImprove: 'Test', lessonLearned: 'Test' })).toBe(true);
+  });
+
+  it('should reject invalid outcomes', () => {
+    expect(isValidReflection({ outcome: 'awesome' })).toBe(false);
+    expect(isValidReflection({ outcome: 123 })).toBe(false);
+  });
+
+  it('should reject non-objects', () => {
+    expect(isValidReflection(null)).toBe(false);
+    expect(isValidReflection('string')).toBe(false);
+    expect(isValidReflection(123)).toBe(false);
+  });
+
+  it('should reject invalid optional field types', () => {
+    expect(isValidReflection({ outcome: 'success', whatWorked: 123 })).toBe(false);
+    expect(isValidReflection({ outcome: 'success', whatToImprove: {} })).toBe(false);
+    expect(isValidReflection({ outcome: 'success', lessonLearned: [] })).toBe(false);
+  });
+});
+
+// ─── Factory Tests ───────────────────────────────────────────────────────────
+
+describe('createEmptyReflection', () => {
+  it('should create default unknown outcome', () => {
+    const result = createEmptyReflection();
+    expect(result).toEqual({ outcome: 'unknown' });
+  });
+
+  it('should accept custom outcome', () => {
+    const result = createEmptyReflection('blocked');
+    expect(result).toEqual({ outcome: 'blocked' });
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Phase 1a** of the Reflexion integration spec (Issue #108), bringing self-critique capabilities to ADA dispatch cycles.

## What's Included

### New Types (types.ts)
- `ReflectionOutcome` — `'success' | 'partial' | 'blocked' | 'unknown'`
- `Reflection` — Self-critique structure with outcome, whatWorked, whatToImprove, lessonLearned
- Extended `RotationHistoryEntry` with optional `reflection` field

### New Module (reflection.ts)
- `generateReflectionPrompt(actionSummary)` — Creates post-action self-critique prompts
- `parseReflection(llmOutput)` — Parses LLM JSON with graceful degradation
- `getRecentReflections(history, role, count)` — Retrieves role-filtered reflections
- `formatReflectionsForContext(role, reflections)` — Formats for dispatch context injection
- `isValidReflection(obj)` — Type guard for validation
- `createEmptyReflection(outcome)` — Factory for minimal reflections

### Tests
- **27 new tests** covering all reflection utilities
- Total: 597 tests passing (570 → 597)

## Token Cost Analysis
Per the spec, this adds ~275 tokens/cycle:
- Reflection prompt: ~50 tokens
- Reflection output: ~75 tokens  
- Loading 3 reflections: ~150 tokens

## Next Steps
- **Phase 1b (Sprint 2, Week 2):** Inject reflections into dispatch context
- **Phase 1c (Sprint 3):** Cross-role insights

## Testing
```bash
npm run typecheck --workspace=packages/core  # ✅
npm test --workspace=packages/core           # ✅ 597 tests (27 new)
npm test --workspace=packages/cli            # ✅ 256 tests
```

## References
- Based on: `docs/research/reflexion-integration-spec.md` (Cycle 228)
- Paper: Shinn et al. (2023) — *Reflexion: Language Agents with Verbal Reinforcement Learning*

Relates to #108

---
🌌 *The Frontier — Cycle 229*