### PR TITLE
fix(cli): UX bugs — banner flag standalone + status stats parsing

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -66,4 +66,11 @@ if (process.argv.length === 2) {
   program.help();
 }
 
+// Handle --banner standalone (without subcommand)
+// preAction hook only fires with subcommands, so we catch it here
+if (process.argv.includes('--banner') && process.argv.length === 3) {
+  showBanner({ force: true });
+  process.exit(0);
+}
+
 program.parse();

--- a/packages/cli/tests/e2e/banner.e2e.test.ts
+++ b/packages/cli/tests/e2e/banner.e2e.test.ts
@@ -1,0 +1,59 @@
+/**
+ * E2E Tests: ada --banner flag
+ *
+ * Issue #136 regression test: --banner flag should work standalone
+ * without requiring a subcommand.
+ *
+ * @module
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createSandbox, type Sandbox } from './harness';
+
+describe('ada --banner E2E — Issue #136 regression', () => {
+  let sandbox: Sandbox;
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.cleanup();
+  });
+
+  describe('--banner flag standalone', () => {
+    it('shows banner and exits cleanly without subcommand', async () => {
+      // This is the regression test for Issue #136
+      // Before the fix, `ada --banner` would show help and exit 1
+      const result = await sandbox.ada(['--banner']);
+
+      expect(result.success).toBe(true);
+      expect(result.exitCode).toBe(0);
+      // Should contain ASCII art (the A D A letters)
+      expect(result.stdout).toMatch(/A\s*D\s*A|ADA|Autonomous Dev Agents/i);
+    });
+
+    it('works with --banner flag in any position', async () => {
+      const result = await sandbox.ada(['--banner']);
+
+      // Should succeed and show banner content
+      expect(result.success).toBe(true);
+      expect(result.stdout.length).toBeGreaterThan(50); // Banner has substantial output
+    });
+  });
+
+  describe('--banner flag with subcommand', () => {
+    beforeEach(async () => {
+      await sandbox.ada(['init']);
+    });
+
+    it('shows banner before status command', async () => {
+      const result = await sandbox.ada(['--banner', 'status']);
+
+      expect(result.success).toBe(true);
+      // Should contain both banner and status output
+      expect(result.stdout).toMatch(/ADA|Autonomous/i);
+      expect(result.stdout).toMatch(/role|cycle/i);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two pre-launch UX issues discovered in Design audit (C445):

### Bug 1: `ada --banner` standalone
- **Problem:** `preAction` hook only fires with subcommands, so `ada --banner` showed help and exited 1
- **Fix:** Check `process.argv` for `--banner` before `program.parse()` when no subcommand given

### Bug 2: `ada status` stats parsing  
- **Problem:** Regex patterns didn't match actual memory bank format
  - Issues expected `(closed, open)` but actual format is `(open, tracked)`
  - Tests expected plain digits but actual format has commas (`1,215+`)
- **Fix:** Updated `extractStats()` regex to handle both formats:
  - Issues: Handles `(53 open, 53 tracked ✅)` and `(6 closed, 23 open)`
  - Tests: Parses numbers with comma separators and `+` suffix

## Verification

| Before | After |
|--------|-------|
| `ada --banner` → shows help, exits 1 | `ada --banner` → shows banner, exits 0 |
| `ada status` → Issues: 0 open / 0 closed | `ada status` → Issues: 53 open / 53 closed |
| `ada status` → Tests: 1 passing | `ada status` → Tests: 1215 passing |

## Tests Added
- **E2E:** `banner.e2e.test.ts` — verifies `--banner` works standalone
- **Unit:** `status.test.ts` — regression tests for new stats formats

## Acceptance Criteria (from #136)
- [x] `ada --banner` shows the full ASCII banner and exits cleanly
- [x] `ada status` correctly parses and displays issue counts
- [x] `ada status` correctly parses test counts with commas/plus
- [x] Add tests for both edge cases

Fixes #136