### PR TITLE
feat(core): add HeatIntegratedStream for automatic heat scoring

### DIFF
--- a/packages/core/src/heat-integrated-stream.ts
+++ b/packages/core/src/heat-integrated-stream.ts
@@ -1,0 +1,464 @@
+/**
+ * @ada/core — Heat-Integrated Memory Stream (Issue #118 — Memory Stream Integration)
+ *
+ * Combines MemoryStream and HeatStore for automatic heat scoring integration.
+ * When memories are logged, corresponding heat entries are created.
+ * When memories are searched, results are automatically combined with heat scores.
+ *
+ * This completes the "memory stream integration" noted as remaining for Issue #118.
+ *
+ * @example
+ * ```typescript
+ * import { HeatIntegratedStream, createHeatIntegratedStream } from '@ada-ai/core';
+ *
+ * const stream = createHeatIntegratedStream('./agents', { enableHeat: true });
+ *
+ * // Log creates both stream entry AND heat entry
+ * const entry = stream.log({
+ *   cycle: 653,
+ *   role: 'engineering',
+ *   action: 'Implemented heat integration',
+ *   content: 'Full heat scoring integration with MemoryStream',
+ *   importance: 8,
+ * });
+ *
+ * // Search automatically combines semantic + heat scores
+ * const results = stream.search('heat integration', { heatWeight: 0.4 });
+ * // Results are ranked by combined score (semantic × heat)
+ * ```
+ *
+ * @see Issue #118 — Heat Scoring Implementation
+ * @see docs/design/heat-scoring-implementation-spec.md
+ * @packageDocumentation
+ */
+
+import * as path from 'path';
+import {
+  MemoryStream,
+  createMemoryStream,
+  type StreamEntry,
+  type StreamEntryInput,
+  type RecallSearchOptions,
+} from './memory-stream.js';
+import {
+  HeatStore,
+  createHeatStore,
+  type HeatEntry,
+  type DecayResult,
+} from './heat/store.js';
+import {
+  combineWithHeat,
+  type HeatRetrievalOptions,
+} from './heat-retrieval.js';
+import type { MemoryClass } from './heat/types.js';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/**
+ * Configuration for HeatIntegratedStream.
+ */
+export interface HeatIntegratedStreamConfig {
+  /**
+   * Enable automatic heat entry creation on memoryLog().
+   * Default: true
+   */
+  readonly enableHeat?: boolean;
+
+  /**
+   * Default memory class for new entries.
+   * 'learned' for agent-acquired knowledge, 'episodic' for transient observations.
+   * Default: 'learned'
+   */
+  readonly defaultMemoryClass?: MemoryClass;
+
+  /**
+   * Weight for heat score in combined ranking (0-1).
+   * Combined = (1 - heatWeight) × semanticScore + heatWeight × heatScore
+   * Default: 0.4
+   */
+  readonly defaultHeatWeight?: number;
+
+  /**
+   * Track references (bump heat) on retrieval.
+   * Default: false (explicit opt-in to avoid inflating scores)
+   */
+  readonly trackOnRetrieval?: boolean;
+}
+
+/**
+ * Extended search options with heat parameters.
+ */
+export interface HeatSearchOptions extends RecallSearchOptions {
+  /**
+   * Enable heat-aware ranking.
+   * Default: true (when heat is enabled)
+   */
+  readonly withHeat?: boolean;
+
+  /**
+   * Weight for heat score (0-1).
+   * Default: config.defaultHeatWeight
+   */
+  readonly heatWeight?: number;
+
+  /**
+   * Minimum heat tier to include ('hot', 'warm', 'cold').
+   * Default: 'cold' (include all)
+   */
+  readonly minTier?: 'hot' | 'warm' | 'cold';
+
+  /**
+   * Track this search as a reference (boosts retrieved entries).
+   * Default: config.trackOnRetrieval
+   */
+  readonly trackAccess?: boolean;
+}
+
+/**
+ * Extended log input with heat parameters.
+ */
+export interface HeatLogInput extends StreamEntryInput {
+  /**
+   * Memory class override for this entry.
+   * Default: config.defaultMemoryClass
+   */
+  readonly memoryClass?: MemoryClass;
+
+  /**
+   * Skip heat entry creation for this log.
+   * Default: false
+   */
+  readonly skipHeat?: boolean;
+}
+
+/**
+ * Combined result from heat-aware search.
+ */
+export interface HeatSearchResult {
+  /** The memory entry */
+  readonly entry: StreamEntry;
+
+  /** Semantic search score (recency × importance × relevance) */
+  readonly semanticScore: number;
+
+  /** Heat score (0-1), undefined if heat disabled or missing */
+  readonly heatScore: number | undefined;
+
+  /** Heat tier ('hot', 'warm', 'cold'), undefined if no heat data */
+  readonly heatTier: 'hot' | 'warm' | 'cold' | undefined;
+
+  /** Combined ranking score */
+  readonly combinedScore: number;
+}
+
+/**
+ * Stats for the integrated stream.
+ */
+export interface IntegratedStreamStats {
+  /** Number of stream entries */
+  readonly streamEntries: number;
+
+  /** Number of heat entries */
+  readonly heatEntries: number;
+
+  /** Number of entries missing heat data (orphans) */
+  readonly missingHeat: number;
+
+  /** Heat tier distribution */
+  readonly heatDistribution: {
+    readonly hot: number;
+    readonly warm: number;
+    readonly cold: number;
+  };
+
+  /** Average heat score */
+  readonly averageHeat: number;
+}
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+/** Default configuration values */
+const DEFAULT_CONFIG: Required<HeatIntegratedStreamConfig> = {
+  enableHeat: true,
+  defaultMemoryClass: 'learned',
+  defaultHeatWeight: 0.4,
+  trackOnRetrieval: false,
+};
+
+// ─── HeatIntegratedStream Class ─────────────────────────────────────────────
+
+/**
+ * Memory stream with automatic heat scoring integration.
+ *
+ * Composes MemoryStream + HeatStore for seamless cognitive memory management.
+ * When you log memories, heat entries are created automatically.
+ * When you search, results are ranked by combined semantic + heat scores.
+ */
+export class HeatIntegratedStream {
+  private readonly stream: MemoryStream;
+  private readonly heatStore: HeatStore;
+  private readonly config: Required<HeatIntegratedStreamConfig>;
+  private heatEnabled: boolean;
+
+  /**
+   * Create a new HeatIntegratedStream.
+   *
+   * @param agentsDir - Path to agents directory (contains memory/ subdirectory)
+   * @param config - Integration configuration
+   */
+  constructor(
+    agentsDir: string,
+    config: HeatIntegratedStreamConfig = {}
+  ) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.heatEnabled = this.config.enableHeat;
+
+    // Initialize underlying components
+    const streamPath = path.join(agentsDir, 'memory', 'stream.jsonl');
+    this.stream = createMemoryStream(streamPath);
+
+    this.heatStore = createHeatStore(agentsDir);
+  }
+
+  /**
+   * Initialize the stream and heat store.
+   * Must be called before using search functionality.
+   */
+  async initialize(): Promise<void> {
+    await this.heatStore.load();
+  }
+
+  /**
+   * Log a memory entry with automatic heat tracking.
+   *
+   * @param input - Memory entry data
+   * @returns The created stream entry
+   */
+  async log(input: HeatLogInput): Promise<StreamEntry> {
+    // Create stream entry
+    const entry = this.stream.memoryLog(input);
+
+    // Create corresponding heat entry (unless disabled)
+    if (this.heatEnabled && !input.skipHeat) {
+      const memoryClass = input.memoryClass ?? this.config.defaultMemoryClass;
+      const now = Date.now();
+
+      const heatEntry: HeatEntry = {
+        id: entry.id,
+        memoryClass,
+        baseImportance: entry.importance / 10, // Normalize 1-10 to 0-1
+        referenceCount: 0,
+        lastAccessedAt: now,
+        createdAt: now,
+      };
+
+      await this.heatStore.set(heatEntry);
+    }
+
+    return entry;
+  }
+
+  /**
+   * Search for relevant memories with heat-aware ranking.
+   *
+   * @param query - Natural language search query
+   * @param options - Search options
+   * @returns Ranked results (semantic × heat combined)
+   */
+  async search(
+    query: string,
+    options: HeatSearchOptions = {}
+  ): Promise<HeatSearchResult[]> {
+    const {
+      withHeat = this.heatEnabled,
+      heatWeight = this.config.defaultHeatWeight,
+      minTier = 'cold',
+      trackAccess = this.config.trackOnRetrieval,
+      ...searchOptions
+    } = options;
+
+    // Get semantic search results
+    const semanticResults = this.stream.recallSearch(query, searchOptions);
+
+    // If heat disabled, return semantic-only results
+    if (!withHeat || !this.heatEnabled) {
+      return semanticResults.map((r) => ({
+        entry: r.entry,
+        semanticScore: r.score,
+        heatScore: undefined,
+        heatTier: undefined,
+        combinedScore: r.score,
+      }));
+    }
+
+    // Combine with heat scores
+    const heatOptions: HeatRetrievalOptions = {
+      minTier,
+      heatWeight,
+      trackAccess,
+    };
+
+    const heatAwareResults = await combineWithHeat(
+      semanticResults,
+      this.heatStore,
+      heatOptions
+    );
+
+    // Map to our result type
+    return heatAwareResults.map((r) => ({
+      entry: r.entry,
+      semanticScore: r.semanticScore,
+      heatScore: r.heatScore,
+      heatTier: r.heatTier,
+      combinedScore: r.combinedScore,
+    }));
+  }
+
+  /**
+   * Boost an entry's heat by incrementing references.
+   *
+   * @param entryId - ID of the entry to boost
+   * @param count - Number of reference increments (default: 1)
+   */
+  async boost(entryId: string, count = 1): Promise<void> {
+    for (let i = 0; i < count; i++) {
+      // Only save on last increment
+      await this.heatStore.increment(entryId, i === count - 1);
+    }
+  }
+
+  /**
+   * Get integrated stats for the stream.
+   */
+  stats(): IntegratedStreamStats {
+    const streamStats = this.stream.getStats();
+    const heatStats = this.heatStore.stats();
+
+    // Count entries missing heat data
+    const allStreamEntries = this.stream.getAllEntries();
+    const allStreamIds = new Set(allStreamEntries.map((e) => e.id));
+    const allHeatIds = new Set(
+      this.heatStore.getAllWithScores().map((e) => e.id)
+    );
+
+    let missingHeat = 0;
+    for (const id of allStreamIds) {
+      if (!allHeatIds.has(id)) {
+        missingHeat++;
+      }
+    }
+
+    return {
+      streamEntries: streamStats.entryCount,
+      heatEntries: heatStats.total,
+      missingHeat,
+      heatDistribution: heatStats.byTier,
+      averageHeat: heatStats.averageHeat,
+    };
+  }
+
+  /**
+   * Initialize heat entries for existing stream entries that don't have them.
+   * Useful for migrating existing streams to heat scoring.
+   *
+   * @returns Number of entries initialized
+   */
+  async initializeMissingHeat(): Promise<number> {
+    const allEntries = this.stream.getAllEntries();
+    const now = Date.now();
+    let initialized = 0;
+
+    for (const entry of allEntries) {
+      // Skip if already has heat data
+      if (this.heatStore.get(entry.id)) {
+        continue;
+      }
+
+      const heatEntry: HeatEntry = {
+        id: entry.id,
+        memoryClass: this.config.defaultMemoryClass,
+        baseImportance: entry.importance / 10,
+        referenceCount: 0,
+        lastAccessedAt: now,
+        createdAt: new Date(entry.timestamp).getTime(),
+      };
+
+      await this.heatStore.set(heatEntry);
+      initialized++;
+    }
+
+    return initialized;
+  }
+
+  /**
+   * Run decay on heat entries.
+   *
+   * @param dryRun - Preview without applying (default: true)
+   * @returns Decay result with processed count and tier changes
+   */
+  runDecay(dryRun = true): Promise<DecayResult> {
+    return this.heatStore.decay({ dryRun });
+  }
+
+  /**
+   * Enable or disable heat integration.
+   */
+  setHeatEnabled(enabled: boolean): void {
+    this.heatEnabled = enabled;
+  }
+
+  /**
+   * Check if heat integration is enabled.
+   */
+  isHeatEnabled(): boolean {
+    return this.heatEnabled;
+  }
+
+  /**
+   * Get the underlying MemoryStream (for advanced usage).
+   */
+  getStream(): MemoryStream {
+    return this.stream;
+  }
+
+  /**
+   * Get the underlying HeatStore (for advanced usage).
+   */
+  getHeatStore(): HeatStore {
+    return this.heatStore;
+  }
+}
+
+// ─── Factory Function ───────────────────────────────────────────────────────
+
+/**
+ * Create and initialize a HeatIntegratedStream.
+ *
+ * @param agentsDir - Path to agents directory
+ * @param config - Integration configuration
+ * @returns Initialized stream ready for use
+ *
+ * @example
+ * ```typescript
+ * const stream = await createHeatIntegratedStream('./agents');
+ *
+ * await stream.log({
+ *   cycle: 653,
+ *   role: 'engineering',
+ *   action: 'Heat integration complete',
+ *   content: 'MemoryStream now auto-creates heat entries',
+ *   importance: 9,
+ * });
+ *
+ * const results = await stream.search('heat integration');
+ * console.log(results[0].combinedScore); // Semantic + heat
+ * ```
+ */
+export async function createHeatIntegratedStream(
+  agentsDir: string,
+  config: HeatIntegratedStreamConfig = {}
+): Promise<HeatIntegratedStream> {
+  const stream = new HeatIntegratedStream(agentsDir, config);
+  await stream.initialize();
+  return stream;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -538,3 +538,18 @@ export {
   SuggestionGenerator,
   createSuggestionGenerator,
 } from './playbook-suggestions/index.js';
+
+// Heat-Integrated Memory Stream (Issue #118 — Memory Stream Integration, C653)
+// Combines MemoryStream + HeatStore for automatic heat scoring.
+// Auto-creates heat entries on memoryLog(), auto-combines scores on search().
+export type {
+  HeatIntegratedStreamConfig,
+  HeatSearchOptions,
+  HeatLogInput,
+  HeatSearchResult,
+  IntegratedStreamStats,
+} from './heat-integrated-stream.js';
+export {
+  HeatIntegratedStream,
+  createHeatIntegratedStream,
+} from './heat-integrated-stream.js';

--- a/packages/core/tests/heat/integrated-stream.test.ts
+++ b/packages/core/tests/heat/integrated-stream.test.ts
@@ -1,0 +1,456 @@
+/**
+ * @ada/core — HeatIntegratedStream Tests (Issue #118 — Memory Stream Integration)
+ *
+ * Tests for the integrated memory stream that combines MemoryStream + HeatStore.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  HeatIntegratedStream,
+  createHeatIntegratedStream,
+} from '../../src/heat-integrated-stream.js';
+
+// ─── Test Fixtures ──────────────────────────────────────────────────────────
+
+const TEST_DIR = path.join(process.cwd(), 'test-output', 'heat-integrated');
+
+function setupTestDir(): void {
+  fs.mkdirSync(path.join(TEST_DIR, 'memory'), { recursive: true });
+}
+
+function cleanupTestDir(): void {
+  if (fs.existsSync(TEST_DIR)) {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('HeatIntegratedStream', () => {
+  beforeEach(() => {
+    cleanupTestDir();
+    setupTestDir();
+  });
+
+  afterEach(() => {
+    cleanupTestDir();
+  });
+
+  describe('constructor', () => {
+    it('creates an instance with default config', () => {
+      const stream = new HeatIntegratedStream(TEST_DIR);
+      expect(stream).toBeInstanceOf(HeatIntegratedStream);
+      expect(stream.isHeatEnabled()).toBe(true);
+    });
+
+    it('respects enableHeat config', () => {
+      const stream = new HeatIntegratedStream(TEST_DIR, { enableHeat: false });
+      expect(stream.isHeatEnabled()).toBe(false);
+    });
+  });
+
+  describe('createHeatIntegratedStream', () => {
+    it('creates and initializes a stream', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+      expect(stream).toBeInstanceOf(HeatIntegratedStream);
+    });
+  });
+
+  describe('log', () => {
+    it('creates a stream entry', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+
+      const entry = await stream.log({
+        cycle: 100,
+        role: 'engineering',
+        action: 'Test action',
+        content: 'Test content for memory entry',
+        importance: 8,
+      });
+
+      expect(entry.id).toBeDefined();
+      expect(entry.cycle).toBe(100);
+      expect(entry.role).toBe('engineering');
+      expect(entry.action).toBe('Test action');
+      expect(entry.importance).toBe(8);
+    });
+
+    it('creates a corresponding heat entry', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+
+      const entry = await stream.log({
+        cycle: 100,
+        role: 'engineering',
+        action: 'Test action',
+        content: 'Test content',
+        importance: 8,
+      });
+
+      const heatStore = stream.getHeatStore();
+      const heatEntry = heatStore.get(entry.id);
+
+      expect(heatEntry).toBeDefined();
+      expect(heatEntry?.id).toBe(entry.id);
+      expect(heatEntry?.baseImportance).toBe(0.8); // 8/10
+      expect(heatEntry?.memoryClass).toBe('learned'); // default
+      expect(heatEntry?.referenceCount).toBe(0);
+    });
+
+    it('respects custom memoryClass', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+
+      const entry = await stream.log({
+        cycle: 100,
+        role: 'qa',
+        action: 'Observation',
+        content: 'Transient observation',
+        importance: 5,
+        memoryClass: 'episodic',
+      });
+
+      const heatStore = stream.getHeatStore();
+      const heatEntry = heatStore.get(entry.id);
+
+      expect(heatEntry?.memoryClass).toBe('episodic');
+    });
+
+    it('respects skipHeat option', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+
+      const entry = await stream.log({
+        cycle: 100,
+        role: 'ops',
+        action: 'Temp action',
+        content: 'No heat needed',
+        importance: 3,
+        skipHeat: true,
+      });
+
+      const heatStore = stream.getHeatStore();
+      const heatEntry = heatStore.get(entry.id);
+
+      expect(heatEntry).toBeNull();
+    });
+
+    it('does not create heat entry when heat disabled', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR, {
+        enableHeat: false,
+      });
+
+      const entry = await stream.log({
+        cycle: 100,
+        role: 'engineering',
+        action: 'Test',
+        content: 'Test',
+        importance: 8,
+      });
+
+      const heatStore = stream.getHeatStore();
+      const heatEntry = heatStore.get(entry.id);
+
+      expect(heatEntry).toBeNull();
+    });
+  });
+
+  describe('search', () => {
+    it('returns results with combined scores when heat enabled', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+
+      // Log some entries
+      await stream.log({
+        cycle: 100,
+        role: 'engineering',
+        action: 'Implement heat scoring',
+        content: 'Added heat calculation module with decay',
+        importance: 9,
+      });
+
+      await stream.log({
+        cycle: 101,
+        role: 'engineering',
+        action: 'Add heat tests',
+        content: 'Unit tests for heat calculation',
+        importance: 7,
+      });
+
+      const results = await stream.search('heat scoring');
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].semanticScore).toBeDefined();
+      expect(results[0].heatScore).toBeDefined();
+      expect(results[0].heatTier).toBeDefined();
+      expect(results[0].combinedScore).toBeDefined();
+    });
+
+    it('returns semantic-only results when withHeat=false', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+
+      await stream.log({
+        cycle: 100,
+        role: 'engineering',
+        action: 'Test entry',
+        content: 'Some test content',
+        importance: 8,
+      });
+
+      const results = await stream.search('test', { withHeat: false });
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].semanticScore).toBeDefined();
+      expect(results[0].heatScore).toBeUndefined();
+      expect(results[0].heatTier).toBeUndefined();
+      // Combined equals semantic when no heat
+      expect(results[0].combinedScore).toBe(results[0].semanticScore);
+    });
+
+    it('filters by heat tier', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+
+      // Log an entry (will be hot initially)
+      await stream.log({
+        cycle: 100,
+        role: 'engineering',
+        action: 'Hot entry',
+        content: 'Fresh and important',
+        importance: 10,
+      });
+
+      // Search with minTier='hot'
+      const hotResults = await stream.search('hot entry', { minTier: 'hot' });
+
+      // Fresh entries with high importance should be hot
+      expect(hotResults.length).toBeGreaterThan(0);
+      expect(hotResults[0].heatTier).toBe('hot');
+    });
+
+    it('respects limit option', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+
+      // Log multiple entries
+      for (let i = 0; i < 10; i++) {
+        await stream.log({
+          cycle: 100 + i,
+          role: 'engineering',
+          action: `Action ${i}`,
+          content: `Content for action ${i}`,
+          importance: 5,
+        });
+      }
+
+      const results = await stream.search('action', { limit: 3 });
+      expect(results.length).toBe(3);
+    });
+  });
+
+  describe('boost', () => {
+    it('increments reference count', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+
+      const entry = await stream.log({
+        cycle: 100,
+        role: 'engineering',
+        action: 'Boostable entry',
+        content: 'Will be boosted',
+        importance: 7,
+      });
+
+      // Check initial reference count
+      let heatEntry = stream.getHeatStore().get(entry.id);
+      expect(heatEntry?.referenceCount).toBe(0);
+
+      // Boost
+      await stream.boost(entry.id);
+
+      heatEntry = stream.getHeatStore().get(entry.id);
+      expect(heatEntry?.referenceCount).toBe(1);
+
+      // Boost multiple times
+      await stream.boost(entry.id, 3);
+
+      heatEntry = stream.getHeatStore().get(entry.id);
+      expect(heatEntry?.referenceCount).toBe(4);
+    });
+  });
+
+  describe('stats', () => {
+    it('returns integrated stats', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+
+      // Log some entries
+      await stream.log({
+        cycle: 100,
+        role: 'engineering',
+        action: 'Entry 1',
+        content: 'Content 1',
+        importance: 9,
+      });
+
+      await stream.log({
+        cycle: 101,
+        role: 'qa',
+        action: 'Entry 2',
+        content: 'Content 2',
+        importance: 6,
+      });
+
+      const stats = stream.stats();
+
+      expect(stats.streamEntries).toBe(2);
+      expect(stats.heatEntries).toBe(2);
+      expect(stats.missingHeat).toBe(0);
+      expect(stats.heatDistribution.hot).toBeGreaterThanOrEqual(0);
+      expect(stats.averageHeat).toBeGreaterThan(0);
+    });
+
+    it('tracks entries missing heat', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+
+      // Log entry with heat
+      await stream.log({
+        cycle: 100,
+        role: 'engineering',
+        action: 'With heat',
+        content: 'Has heat entry',
+        importance: 8,
+      });
+
+      // Log entry without heat
+      await stream.log({
+        cycle: 101,
+        role: 'ops',
+        action: 'Without heat',
+        content: 'Skipped heat',
+        importance: 5,
+        skipHeat: true,
+      });
+
+      const stats = stream.stats();
+
+      expect(stats.streamEntries).toBe(2);
+      expect(stats.heatEntries).toBe(1);
+      expect(stats.missingHeat).toBe(1);
+    });
+  });
+
+  describe('initializeMissingHeat', () => {
+    it('creates heat entries for entries that lack them', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+
+      // Log entries without heat
+      await stream.log({
+        cycle: 100,
+        role: 'engineering',
+        action: 'Entry 1',
+        content: 'Content 1',
+        importance: 8,
+        skipHeat: true,
+      });
+
+      await stream.log({
+        cycle: 101,
+        role: 'qa',
+        action: 'Entry 2',
+        content: 'Content 2',
+        importance: 6,
+        skipHeat: true,
+      });
+
+      // Check missing
+      let stats = stream.stats();
+      expect(stats.missingHeat).toBe(2);
+
+      // Initialize missing heat
+      const initialized = await stream.initializeMissingHeat();
+      expect(initialized).toBe(2);
+
+      // Check again
+      stats = stream.stats();
+      expect(stats.missingHeat).toBe(0);
+      expect(stats.heatEntries).toBe(2);
+    });
+
+    it('skips entries that already have heat', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+
+      // Log entry with heat
+      await stream.log({
+        cycle: 100,
+        role: 'engineering',
+        action: 'With heat',
+        content: 'Has heat',
+        importance: 8,
+      });
+
+      // Initialize (should be 0 since all have heat)
+      const initialized = await stream.initializeMissingHeat();
+      expect(initialized).toBe(0);
+    });
+  });
+
+  describe('setHeatEnabled', () => {
+    it('toggles heat integration', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+      expect(stream.isHeatEnabled()).toBe(true);
+
+      stream.setHeatEnabled(false);
+      expect(stream.isHeatEnabled()).toBe(false);
+
+      // Log entry when disabled
+      const entry = await stream.log({
+        cycle: 100,
+        role: 'engineering',
+        action: 'Disabled heat',
+        content: 'Content',
+        importance: 8,
+      });
+
+      const heatEntry = stream.getHeatStore().get(entry.id);
+      expect(heatEntry).toBeNull();
+
+      // Re-enable and log
+      stream.setHeatEnabled(true);
+      const entry2 = await stream.log({
+        cycle: 101,
+        role: 'engineering',
+        action: 'Enabled heat',
+        content: 'Content',
+        importance: 8,
+      });
+
+      const heatEntry2 = stream.getHeatStore().get(entry2.id);
+      expect(heatEntry2).toBeDefined();
+    });
+  });
+
+  describe('runDecay', () => {
+    it('runs decay pass on heat store', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+
+      await stream.log({
+        cycle: 100,
+        role: 'engineering',
+        action: 'Entry',
+        content: 'Content',
+        importance: 8,
+      });
+
+      // Run decay (dry run)
+      const result = await stream.runDecay(true);
+
+      expect(result.processed).toBeGreaterThanOrEqual(0);
+      expect(result.tierChanges).toBeDefined();
+      expect(result.archived).toBeDefined();
+    });
+  });
+
+  describe('getStream and getHeatStore', () => {
+    it('exposes underlying components', async () => {
+      const stream = await createHeatIntegratedStream(TEST_DIR);
+
+      expect(stream.getStream()).toBeDefined();
+      expect(stream.getHeatStore()).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements Memory Stream × Heat integration for Issue #118 (Task: memory stream integration).

When you log memories with `HeatIntegratedStream`, corresponding heat entries are created automatically. When you search, results are ranked by combined semantic + heat scores.

## Type of Change

- [x] feat (new feature)

## Related Issues

- Relates to #118 — Heat Scoring Implementation
- Completes 'memory stream integration' noted in memory bank

## Changes Made

### New Module: `heat-integrated-stream.ts`

- **HeatIntegratedStream** class composing MemoryStream + HeatStore
- **log()** — Creates StreamEntry AND corresponding HeatEntry automatically
- **search()** — Returns combined semantic + heat scores
- **boost()** — Increment reference counts to boost heat
- **stats()** — Integrated statistics (stream + heat + missing)
- **initializeMissingHeat()** — Migrate existing streams to heat scoring
- **runDecay()** — Apply time-based decay

### Exports Added to index.ts

```typescript
// Types
HeatIntegratedStreamConfig
HeatSearchOptions
HeatLogInput
HeatSearchResult
IntegratedStreamStats

// Functions
HeatIntegratedStream
createHeatIntegratedStream()
```

## Testing

- [x] TypeScript strict mode passes
- [x] ESLint passes
- [x] +20 new tests (integrated-stream.test.ts)
- [x] Full test suite: 1055 tests pass

```
Test Files  35 passed (35)
     Tests  1051 passed | 4 skipped (1055)
```

## Usage Example

```typescript
import { createHeatIntegratedStream } from '@ada-ai/core';

const stream = await createHeatIntegratedStream('./agents');

// Auto-creates heat entry
await stream.log({
  cycle: 653,
  role: 'engineering',
  action: 'Heat integration complete',
  content: 'MemoryStream now auto-creates heat entries',
  importance: 9,
});

// Combined semantic + heat ranking
const results = await stream.search('heat integration');
console.log(results[0].combinedScore);
```

---

**⚙️ The Builder (Engineering, C653)**