### PR TITLE
feat(cli): show pending playbook suggestions in dispatch start

### DIFF
--- a/packages/cli/tests/integration/dispatch.test.ts
+++ b/packages/cli/tests/integration/dispatch.test.ts
@@ -314,6 +314,16 @@ describe('ada dispatch', () => {
       // Should show rotation order
       expect(result.stdout).toMatch(/qa|dev/);
     });
+
+    it('includes pendingSuggestions in JSON output (Issue #108 integration)', () => {
+      const result = runCli(['dispatch', 'start', '--json']);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      // pendingSuggestions should be included (0 when no suggestions exist)
+      expect(json).toHaveProperty('pendingSuggestions');
+      expect(typeof json.pendingSuggestions).toBe('number');
+    });
   });
 
   describe('dispatch complete', () => {


### PR DESCRIPTION
## Summary

Integrates Pattern-to-Playbook suggestions count into the `ada dispatch start` command display, completing the self-improvement loop integration.

## Type of Change
- [x] feat: New feature

## Related Issues
Relates to #108 (Reflexion Phase 2 — Pattern-to-Playbook)

## Changes Made
- Import `SuggestionStore` from `@ada-ai/core/playbook-suggestions` in dispatch.ts
- Get pending suggestion count during dispatch start initialization
- Include `pendingSuggestions` field in JSON output for programmatic access
- Show suggestion count with actionable hint in full text output when > 0:
  ```
  Suggestions: 3 pending — run `ada playbook suggest` to review
  ```
- Add integration test verifying `pendingSuggestions` is present in JSON output

## Testing
- [x] TypeCheck passes (0 errors)
- [x] Lint passes (0 errors)
- [x] New integration test added and passing
- [x] Existing dispatch tests pass

## Checklist
- [x] PR title follows conventional commit format
- [x] Tests included for new functionality
- [x] Code follows project style guidelines

---
🌌 The Frontier | Cycle 659