### PR TITLE
test(cli): add tests for ada issues and ada costs commands

### DIFF
--- a/packages/cli/src/commands/__tests__/costs.test.ts
+++ b/packages/cli/src/commands/__tests__/costs.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for `ada costs` command
+ *
+ * Validates cost tracking CLI commands including:
+ * - Quick cost summary display
+ * - JSON output for scripting
+ * - Export to CSV/TSV/JSON files
+ *
+ * @see packages/cli/src/commands/costs.ts
+ * @see Issue #69 — Observability specification
+ * @see Issue #94 — Export specification
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { costsCommand } from '../costs.js';
+
+// Mock console to capture output
+const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+describe('costs command', () => {
+  beforeEach(() => {
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  afterEach(() => {
+    mockConsoleLog.mockReset();
+    mockConsoleError.mockReset();
+  });
+
+  describe('command structure', () => {
+    it('should have correct name', () => {
+      expect(costsCommand.name()).toBe('costs');
+    });
+
+    it('should have description about cost checking', () => {
+      expect(costsCommand.description()).toContain('cost');
+    });
+
+    it('should have --dir option with default', () => {
+      const dirOption = costsCommand.options.find((opt) => opt.long === '--dir');
+      expect(dirOption).toBeDefined();
+      expect(dirOption?.defaultValue).toBe('agents');
+    });
+
+    it('should have --json option', () => {
+      const jsonOption = costsCommand.options.find((opt) => opt.long === '--json');
+      expect(jsonOption).toBeDefined();
+    });
+
+    it('should have --export option', () => {
+      const exportOption = costsCommand.options.find((opt) => opt.long === '--export');
+      expect(exportOption).toBeDefined();
+    });
+
+    it('should have --force option', () => {
+      const forceOption = costsCommand.options.find((opt) => opt.long === '--force');
+      expect(forceOption).toBeDefined();
+    });
+
+    it('should have short alias -d for --dir', () => {
+      const dirOption = costsCommand.options.find((opt) => opt.short === '-d');
+      expect(dirOption).toBeDefined();
+      expect(dirOption?.long).toBe('--dir');
+    });
+
+    it('should have short alias -e for --export', () => {
+      const exportOption = costsCommand.options.find((opt) => opt.short === '-e');
+      expect(exportOption).toBeDefined();
+      expect(exportOption?.long).toBe('--export');
+    });
+
+    it('should have short alias -f for --force', () => {
+      const forceOption = costsCommand.options.find((opt) => opt.short === '-f');
+      expect(forceOption).toBeDefined();
+      expect(forceOption?.long).toBe('--force');
+    });
+  });
+});
+
+describe('costs command integration', () => {
+  // These tests require mocking metrics manager and file system
+
+  it.skip('should show empty state when no metrics exist', async () => {
+    // TODO: Mock createMetricsManager to return empty cycles
+    // Verify "No cost data collected yet" message
+  });
+
+  it.skip('should show cost breakdown with today/week/total', async () => {
+    // TODO: Mock createMetricsManager with cycle data
+    // Verify output contains Today, This week, All time, Avg/cycle
+  });
+
+  it.skip('should output JSON when --json flag is provided', async () => {
+    // TODO: Mock createMetricsManager with cycle data
+    // Verify output is valid JSON with today, week, total, avgPerCycle, model
+  });
+
+  it.skip('should export to CSV when --export costs.csv is provided', async () => {
+    // TODO: Mock createMetricsManager and writeFile
+    // Verify CSV format with headers
+  });
+
+  it.skip('should export to TSV when --export costs.tsv is provided', async () => {
+    // TODO: Mock createMetricsManager and writeFile
+    // Verify TSV format with tabs
+  });
+
+  it.skip('should export to JSON when --export costs.json is provided', async () => {
+    // TODO: Mock createMetricsManager and writeFile
+    // Verify JSON format with all cost data
+  });
+
+  it.skip('should prompt for overwrite confirmation when file exists', async () => {
+    // TODO: Mock fileExists to return true
+    // Verify confirmation prompt is shown
+  });
+
+  it.skip('should skip confirmation when --force is provided', async () => {
+    // TODO: Mock fileExists to return true
+    // Verify no confirmation prompt with --force
+  });
+
+  it.skip('should reject unsupported export extensions', async () => {
+    // TODO: Try to export to .txt
+    // Verify error about unsupported extension
+  });
+
+  it.skip('should calculate today cost correctly', async () => {
+    // TODO: Mock cycles spanning multiple days
+    // Verify only today's cycles are included in today cost
+  });
+
+  it.skip('should calculate week cost correctly', async () => {
+    // TODO: Mock cycles spanning multiple weeks
+    // Verify only last 7 days are included in week cost
+  });
+
+  it.skip('should handle metrics manager errors gracefully', async () => {
+    // TODO: Mock createMetricsManager to throw
+    // Verify user-friendly error message
+  });
+});

--- a/packages/cli/src/commands/__tests__/issues.test.ts
+++ b/packages/cli/src/commands/__tests__/issues.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for `ada issues` command
+ *
+ * Validates issue tracking CLI commands including:
+ * - verify: Check if all open issues are tracked in Active Threads
+ * - sync: Automatically update Active Threads with missing issues
+ * - list: List categorized issues (active/backlog)
+ *
+ * @see packages/cli/src/commands/issues.ts
+ * @see R-013: Issue Tracking Protocol
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { issuesCommand } from '../issues.js';
+
+// Mock console.log to capture output
+const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+describe('issues command', () => {
+  beforeEach(() => {
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  afterEach(() => {
+    mockConsoleLog.mockReset();
+    mockConsoleError.mockReset();
+  });
+
+  describe('command structure', () => {
+    it('should have correct name', () => {
+      expect(issuesCommand.name()).toBe('issues');
+    });
+
+    it('should have description referencing R-013', () => {
+      expect(issuesCommand.description()).toContain('Issue tracking');
+      expect(issuesCommand.description()).toContain('R-013');
+    });
+
+    it('should have verify subcommand', () => {
+      const verifyCmd = issuesCommand.commands.find((cmd) => cmd.name() === 'verify');
+      expect(verifyCmd).toBeDefined();
+    });
+
+    it('should have sync subcommand', () => {
+      const syncCmd = issuesCommand.commands.find((cmd) => cmd.name() === 'sync');
+      expect(syncCmd).toBeDefined();
+    });
+
+    it('should have list subcommand', () => {
+      const listCmd = issuesCommand.commands.find((cmd) => cmd.name() === 'list');
+      expect(listCmd).toBeDefined();
+    });
+  });
+
+  describe('verify subcommand options', () => {
+    it('should have --dir option', () => {
+      const verifyCmd = issuesCommand.commands.find((cmd) => cmd.name() === 'verify');
+      const dirOption = verifyCmd?.options.find((opt) => opt.long === '--dir');
+      expect(dirOption).toBeDefined();
+    });
+
+    it('should have --json option', () => {
+      const verifyCmd = issuesCommand.commands.find((cmd) => cmd.name() === 'verify');
+      const jsonOption = verifyCmd?.options.find((opt) => opt.long === '--json');
+      expect(jsonOption).toBeDefined();
+    });
+
+    it('should have --verbose option', () => {
+      const verifyCmd = issuesCommand.commands.find((cmd) => cmd.name() === 'verify');
+      const verboseOption = verifyCmd?.options.find((opt) => opt.long === '--verbose');
+      expect(verboseOption).toBeDefined();
+    });
+
+    it('should have description about checking Active Threads', () => {
+      const verifyCmd = issuesCommand.commands.find((cmd) => cmd.name() === 'verify');
+      expect(verifyCmd?.description()).toContain('Active Threads');
+    });
+  });
+
+  describe('sync subcommand options', () => {
+    it('should have --dir option', () => {
+      const syncCmd = issuesCommand.commands.find((cmd) => cmd.name() === 'sync');
+      const dirOption = syncCmd?.options.find((opt) => opt.long === '--dir');
+      expect(dirOption).toBeDefined();
+    });
+
+    it('should have --dry-run option', () => {
+      const syncCmd = issuesCommand.commands.find((cmd) => cmd.name() === 'sync');
+      const dryRunOption = syncCmd?.options.find((opt) => opt.long === '--dry-run');
+      expect(dryRunOption).toBeDefined();
+    });
+
+    it('should have --json option', () => {
+      const syncCmd = issuesCommand.commands.find((cmd) => cmd.name() === 'sync');
+      const jsonOption = syncCmd?.options.find((opt) => opt.long === '--json');
+      expect(jsonOption).toBeDefined();
+    });
+
+    it('should have description about syncing Active Threads', () => {
+      const syncCmd = issuesCommand.commands.find((cmd) => cmd.name() === 'sync');
+      expect(syncCmd?.description()).toContain('Sync');
+      expect(syncCmd?.description()).toContain('Active Threads');
+    });
+  });
+
+  describe('list subcommand options', () => {
+    it('should have --dir option', () => {
+      const listCmd = issuesCommand.commands.find((cmd) => cmd.name() === 'list');
+      const dirOption = listCmd?.options.find((opt) => opt.long === '--dir');
+      expect(dirOption).toBeDefined();
+    });
+
+    it('should have --category option', () => {
+      const listCmd = issuesCommand.commands.find((cmd) => cmd.name() === 'list');
+      const categoryOption = listCmd?.options.find((opt) => opt.long === '--category');
+      expect(categoryOption).toBeDefined();
+    });
+
+    it('should have --json option', () => {
+      const listCmd = issuesCommand.commands.find((cmd) => cmd.name() === 'list');
+      const jsonOption = listCmd?.options.find((opt) => opt.long === '--json');
+      expect(jsonOption).toBeDefined();
+    });
+
+    it('should have description about listing categorized issues', () => {
+      const listCmd = issuesCommand.commands.find((cmd) => cmd.name() === 'list');
+      expect(listCmd?.description()).toContain('categorized');
+    });
+  });
+});
+
+describe('issues command integration', () => {
+  // These tests require mocking gh CLI and file system
+
+  it.skip('should show 100% compliance when all issues are tracked', async () => {
+    // TODO: Mock gh CLI output and bank.md content
+    // Verify compliance output shows 100%
+  });
+
+  it.skip('should detect missing issues in Active Threads', async () => {
+    // TODO: Mock gh CLI with issues not in bank.md
+    // Verify missing issues are listed
+  });
+
+  it.skip('should detect closed issues still in Active Threads', async () => {
+    // TODO: Mock gh CLI with closed issues
+    // Verify stale entries are flagged
+  });
+
+  it.skip('should sync missing issues with --dry-run showing changes', async () => {
+    // TODO: Mock gh CLI and file system
+    // Verify dry-run shows changes without writing
+  });
+
+  it.skip('should sync missing issues and write to bank.md', async () => {
+    // TODO: Mock gh CLI and file system
+    // Verify bank.md is updated with missing issues
+  });
+
+  it.skip('should list active issues (P0-P1) separately', async () => {
+    // TODO: Mock gh CLI and bank.md
+    // Verify active issues are listed in correct section
+  });
+
+  it.skip('should list backlog issues (P2-P3) separately', async () => {
+    // TODO: Mock gh CLI and bank.md
+    // Verify backlog issues are listed in correct section
+  });
+
+  it.skip('should filter list by category when --category is provided', async () => {
+    // TODO: Mock gh CLI and bank.md
+    // Verify only specified category is shown
+  });
+
+  it.skip('should output JSON when --json flag is provided', async () => {
+    // TODO: Mock gh CLI and bank.md
+    // Verify output is valid JSON
+  });
+
+  it.skip('should show verbose information when --verbose is provided', async () => {
+    // TODO: Mock gh CLI and bank.md
+    // Verify priority, role, and labels are shown
+  });
+
+  it.skip('should handle gh CLI errors gracefully', async () => {
+    // TODO: Mock gh CLI to fail
+    // Verify user-friendly error message
+  });
+
+  it.skip('should handle missing bank.md gracefully', async () => {
+    // TODO: Mock file system to return ENOENT
+    // Verify user-friendly error message
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for two CLI commands that were missing test coverage: `ada issues` and `ada costs`.

## Type of Change

- [x] test — Improving test coverage

## Related Issues

Relates to #34 (E2E Testing Infrastructure)

## Changes Made

### `ada issues` command tests (29 tests)
- Tests command structure and name
- Tests all subcommands: verify, sync, list
- Tests all options: --dir, --json, --verbose, --dry-run, --category
- Integration test stubs for future mock implementation

### `ada costs` command tests (21 tests)
- Tests command structure and name
- Tests all options: --dir, --json, --export, --force
- Tests short aliases: -d, -e, -f
- Integration test stubs for future mock implementation

## Testing

```bash
# Run new tests
cd packages/cli && npx vitest run src/commands/__tests__/issues.test.ts
cd packages/cli && npx vitest run src/commands/__tests__/costs.test.ts

# Run all command tests
cd packages/cli && npx vitest run src/commands/__tests__
```

All tests pass:
- issues.test.ts: 17 passed, 12 skipped
- costs.test.ts: 9 passed, 12 skipped

## Checklist

- [x] Conventional commit title
- [x] Tests included
- [x] TypeScript strict mode passes
- [x] ESLint passes

---
*Author: ⚙️ The Builder (Engineering) — Cycle 695*