### PR TITLE
feat(core): add model router for role-based LLM selection

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -553,3 +553,47 @@ export {
   HeatIntegratedStream,
   createHeatIntegratedStream,
 } from './heat-integrated-stream.js';
+
+// Model Routing (Research C723 — Role-Based LLM Selection, Frontier C724)
+// Cost optimization via role-based model selection: 35% Haiku, 62% Sonnet, 3% Opus.
+// Expected savings: 14% vs all-Sonnet baseline ($0.051 → $0.044/cycle).
+export type {
+  ClaudeModel,
+  ModelTier,
+  RoleId as ModelRoleId,
+  ActionType,
+  TaskComplexity,
+  ModelInfo,
+  ModelRoutingConfig,
+  RoleModelOverride,
+  FallbackConfig,
+  FallbackTrigger,
+  FallbackRules,
+  ModelSelectionResult,
+  DispatchOutput,
+  ValidationResult as ModelValidationResult,
+  CycleModelMetrics,
+} from './models/index.js';
+export {
+  MODEL_INFO,
+  AVG_TOKENS_PER_CYCLE,
+  DEFAULT_ROUTING_CONFIG,
+  DEFAULT_FALLBACK_RULES,
+  calculateCycleCost,
+  getModelTier,
+  isComplexRole,
+  inferActionType,
+  selectModel,
+  getFallbackModel,
+  getModelDistribution,
+  calculateProjectedCycleCost,
+  ModelRouter,
+  MIN_ACTION_LENGTH,
+  MAX_ACTION_LENGTH,
+  ROLE_ACTION_KEYWORDS,
+  validateDispatchOutput,
+  isValidPrUrl,
+  isValidCommitMessage,
+  parseDispatchOutput,
+  calculateQualityScore,
+} from './models/index.js';

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -1,0 +1,61 @@
+/**
+ * Model Routing Module
+ *
+ * Role-based LLM model selection for cost optimization.
+ * Implements Research C723 recommendations:
+ * - 35% Haiku (routine tasks)
+ * - 62% Sonnet (standard/complex tasks)
+ * - 3% Opus (critical CEO decisions)
+ *
+ * Expected savings: 14% vs all-Sonnet baseline
+ *
+ * @packageDocumentation
+ */
+
+// Types
+export type {
+  ClaudeModel,
+  ModelTier,
+  RoleId,
+  ActionType,
+  TaskComplexity,
+  ModelInfo,
+  ModelRoutingConfig,
+  RoleModelOverride,
+  FallbackConfig,
+  FallbackTrigger,
+  FallbackRules,
+  ModelSelectionResult,
+  DispatchOutput,
+  ValidationResult,
+  CycleModelMetrics,
+} from './types.js';
+
+// Router
+export {
+  MODEL_INFO,
+  AVG_TOKENS_PER_CYCLE,
+  DEFAULT_ROUTING_CONFIG,
+  DEFAULT_FALLBACK_RULES,
+  calculateCycleCost,
+  getModelTier,
+  isComplexRole,
+  inferActionType,
+  selectModel,
+  getFallbackModel,
+  getModelDistribution,
+  calculateProjectedCycleCost,
+  ModelRouter,
+} from './router.js';
+
+// Validation
+export {
+  MIN_ACTION_LENGTH,
+  MAX_ACTION_LENGTH,
+  ROLE_ACTION_KEYWORDS,
+  validateDispatchOutput,
+  isValidPrUrl,
+  isValidCommitMessage,
+  parseDispatchOutput,
+  calculateQualityScore,
+} from './validation.js';

--- a/packages/core/src/models/router.ts
+++ b/packages/core/src/models/router.ts
@@ -1,0 +1,395 @@
+/**
+ * Model Router
+ *
+ * Role-based LLM model selection for dispatch cycles.
+ * Implements cost optimization strategy from Research C723.
+ *
+ * Strategy: 35% Haiku, 62% Sonnet, 3% Opus
+ * Target savings: 14% ($0.051 → $0.044/cycle)
+ *
+ * @packageDocumentation
+ */
+
+import type {
+  ClaudeModel,
+  ModelTier,
+  RoleId,
+  ActionType,
+  ModelInfo,
+  ModelRoutingConfig,
+  RoleModelOverride,
+  FallbackRules,
+  FallbackTrigger,
+  ModelSelectionResult,
+} from './types.js';
+
+/**
+ * Model metadata registry.
+ */
+export const MODEL_INFO: Readonly<Record<ClaudeModel, ModelInfo>> = {
+  'claude-3-5-haiku-20241022': {
+    model: 'claude-3-5-haiku-20241022',
+    tier: 'fast',
+    inputCostPerMillion: 0.8,
+    outputCostPerMillion: 4.0,
+    contextWindow: 200_000,
+    suitableFor: ['routine'] as const,
+  },
+  'claude-3-5-sonnet-20241022': {
+    model: 'claude-3-5-sonnet-20241022',
+    tier: 'balanced',
+    inputCostPerMillion: 3.0,
+    outputCostPerMillion: 15.0,
+    contextWindow: 200_000,
+    suitableFor: ['routine', 'standard', 'complex'] as const,
+  },
+  'claude-3-opus-20240229': {
+    model: 'claude-3-opus-20240229',
+    tier: 'premium',
+    inputCostPerMillion: 15.0,
+    outputCostPerMillion: 75.0,
+    contextWindow: 200_000,
+    suitableFor: ['routine', 'standard', 'complex', 'critical'] as const,
+  },
+} as const;
+
+/**
+ * Average token usage per cycle (from Research C723 analysis).
+ */
+export const AVG_TOKENS_PER_CYCLE = {
+  input: 5000,
+  output: 2000,
+  tools: 1000,
+} as const;
+
+/**
+ * Default routing configuration based on Research C723 recommendations.
+ */
+export const DEFAULT_ROUTING_CONFIG: ModelRoutingConfig = {
+  default: 'claude-3-5-sonnet-20241022',
+
+  roleOverrides: {
+    // Routine roles → Haiku (35% of cycles)
+    scrum: 'claude-3-5-haiku-20241022',
+    evangelist: 'claude-3-5-haiku-20241022',
+
+    // Ops with action-level routing
+    ops: {
+      default: 'claude-3-5-sonnet-20241022',
+      actions: {
+        merge: 'claude-3-5-haiku-20241022',
+        triage: 'claude-3-5-haiku-20241022',
+        infra: 'claude-3-5-sonnet-20241022',
+        default: 'claude-3-5-sonnet-20241022',
+      },
+    },
+
+    // CEO with action-level routing for strategic decisions
+    ceo: {
+      default: 'claude-3-5-sonnet-20241022',
+      actions: {
+        endorse: 'claude-3-opus-20240229',
+        pivot: 'claude-3-opus-20240229',
+        adr: 'claude-3-opus-20240229',
+        launch: 'claude-3-opus-20240229',
+        default: 'claude-3-5-sonnet-20241022',
+      },
+    },
+  },
+
+  // Roles that should never use Haiku
+  complexRoles: ['engineering', 'research', 'frontier', 'design'],
+
+  enableFallback: true,
+} as const;
+
+/**
+ * Default fallback rules for model failures.
+ */
+export const DEFAULT_FALLBACK_RULES: FallbackRules = {
+  haiku: {
+    fallbackTo: 'claude-3-5-sonnet-20241022',
+    triggerOn: ['validation_failure', 'incomplete_output', 'format_error'],
+    maxRetries: 1,
+  },
+  sonnet: {
+    fallbackTo: 'claude-3-opus-20240229',
+    triggerOn: ['reasoning_failure', 'critical_task'],
+    maxRetries: 1,
+  },
+} as const;
+
+/**
+ * Calculate estimated cost per cycle for a model.
+ */
+export function calculateCycleCost(model: ClaudeModel): number {
+  const info = MODEL_INFO[model];
+  const inputCost = (AVG_TOKENS_PER_CYCLE.input / 1_000_000) * info.inputCostPerMillion;
+  const outputCost = (AVG_TOKENS_PER_CYCLE.output / 1_000_000) * info.outputCostPerMillion;
+  const toolCost = (AVG_TOKENS_PER_CYCLE.tools / 1_000_000) * info.inputCostPerMillion;
+  return inputCost + outputCost + toolCost;
+}
+
+/**
+ * Get the model tier.
+ */
+export function getModelTier(model: ClaudeModel): ModelTier {
+  return MODEL_INFO[model].tier;
+}
+
+/**
+ * Check if a role is in the complex roles list.
+ */
+export function isComplexRole(role: RoleId, config: ModelRoutingConfig = DEFAULT_ROUTING_CONFIG): boolean {
+  return config.complexRoles.includes(role);
+}
+
+/**
+ * Parse action type from action description.
+ * Looks for keywords to determine if this is a merge, triage, strategic decision, etc.
+ */
+export function inferActionType(role: RoleId, actionDescription: string): ActionType {
+  const lower = actionDescription.toLowerCase();
+
+  if (role === 'ops') {
+    if (lower.includes('merge') || lower.includes('merged')) return 'merge';
+    if (lower.includes('triage') || lower.includes('review')) return 'triage';
+    if (lower.includes('infra') || lower.includes('ci') || lower.includes('workflow')) return 'infra';
+  }
+
+  if (role === 'ceo') {
+    if (lower.includes('endorse') || lower.includes('endorsement')) return 'endorse';
+    if (lower.includes('pivot') || lower.includes('strategic shift')) return 'pivot';
+    if (lower.includes('adr') || lower.includes('architecture decision')) return 'adr';
+    if (lower.includes('launch') || lower.includes('go/no-go')) return 'launch';
+  }
+
+  return 'default';
+}
+
+/**
+ * Select the appropriate model for a role and action.
+ *
+ * @param role - Role executing the dispatch
+ * @param actionDescription - Optional action description for action-level routing
+ * @param config - Routing configuration (defaults to DEFAULT_ROUTING_CONFIG)
+ * @returns Model selection result with reasoning
+ */
+export function selectModel(
+  role: RoleId,
+  actionDescription?: string,
+  config: ModelRoutingConfig = DEFAULT_ROUTING_CONFIG
+): ModelSelectionResult {
+  const actionType = actionDescription ? inferActionType(role, actionDescription) : 'default';
+
+  // Check for role-specific override
+  const roleOverride = config.roleOverrides[role];
+
+  let model: ClaudeModel;
+  let reason: string;
+
+  if (roleOverride === undefined) {
+    // No override, use default
+    model = config.default;
+    reason = `Default model (no role override for ${role})`;
+  } else if (typeof roleOverride === 'string') {
+    // Simple role → model mapping
+    model = roleOverride;
+    reason = `Role override: ${role} → ${model}`;
+  } else {
+    // Role has action-level routing
+    const roleConfig = roleOverride as RoleModelOverride;
+    if (roleConfig.actions && actionType !== 'default' && roleConfig.actions[actionType]) {
+      model = roleConfig.actions[actionType];
+      reason = `Action override: ${role}/${actionType} → ${model}`;
+    } else {
+      model = roleConfig.default;
+      reason = `Role default: ${role} → ${model}`;
+    }
+  }
+
+  // Safety check: complex roles should never use Haiku
+  if (isComplexRole(role, config) && model === 'claude-3-5-haiku-20241022') {
+    model = config.default;
+    reason = `Upgraded from Haiku: ${role} is a complex role`;
+  }
+
+  return {
+    model,
+    tier: getModelTier(model),
+    reason,
+    estimatedCostPerCycle: calculateCycleCost(model),
+    isFallback: false,
+  };
+}
+
+/**
+ * Get the fallback model for a given model when a trigger condition occurs.
+ *
+ * @param currentModel - The model that failed
+ * @param trigger - What caused the failure
+ * @param rules - Fallback rules (defaults to DEFAULT_FALLBACK_RULES)
+ * @returns Fallback model selection result, or null if no fallback applies
+ */
+export function getFallbackModel(
+  currentModel: ClaudeModel,
+  trigger: FallbackTrigger,
+  rules: FallbackRules = DEFAULT_FALLBACK_RULES
+): ModelSelectionResult | null {
+  const tier = getModelTier(currentModel);
+
+  // Haiku → Sonnet fallback
+  if (tier === 'fast' && rules.haiku.triggerOn.includes(trigger)) {
+    return {
+      model: rules.haiku.fallbackTo,
+      tier: getModelTier(rules.haiku.fallbackTo),
+      reason: `Fallback from Haiku: ${trigger}`,
+      estimatedCostPerCycle: calculateCycleCost(rules.haiku.fallbackTo),
+      isFallback: true,
+      originalModel: currentModel,
+    };
+  }
+
+  // Sonnet → Opus fallback
+  if (tier === 'balanced' && rules.sonnet.triggerOn.includes(trigger)) {
+    return {
+      model: rules.sonnet.fallbackTo,
+      tier: getModelTier(rules.sonnet.fallbackTo),
+      reason: `Fallback from Sonnet: ${trigger}`,
+      estimatedCostPerCycle: calculateCycleCost(rules.sonnet.fallbackTo),
+      isFallback: true,
+      originalModel: currentModel,
+    };
+  }
+
+  // Opus has no fallback (already premium tier)
+  return null;
+}
+
+/**
+ * Get model distribution statistics based on config.
+ * Used for cost projections.
+ */
+export function getModelDistribution(config: ModelRoutingConfig = DEFAULT_ROUTING_CONFIG): Record<ClaudeModel, number> {
+  // Based on Research C723 analysis of role frequency
+  const roleFrequency: Record<RoleId, number> = {
+    ceo: 0.09, // ~9% of cycles
+    growth: 0.09,
+    research: 0.09,
+    frontier: 0.09,
+    product: 0.09,
+    scrum: 0.09,
+    qa: 0.09,
+    engineering: 0.09,
+    ops: 0.09,
+    design: 0.09,
+    evangelist: 0.10, // Slightly higher due to outreach focus
+  };
+
+  const distribution: Record<ClaudeModel, number> = {
+    'claude-3-5-haiku-20241022': 0,
+    'claude-3-5-sonnet-20241022': 0,
+    'claude-3-opus-20240229': 0,
+  };
+
+  for (const [roleStr, freq] of Object.entries(roleFrequency)) {
+    const role = roleStr as RoleId;
+    const selection = selectModel(role, undefined, config);
+    distribution[selection.model] += freq;
+  }
+
+  return distribution;
+}
+
+/**
+ * Calculate projected average cost per cycle.
+ */
+export function calculateProjectedCycleCost(config: ModelRoutingConfig = DEFAULT_ROUTING_CONFIG): number {
+  const distribution = getModelDistribution(config);
+  let totalCost = 0;
+
+  for (const [model, freq] of Object.entries(distribution)) {
+    totalCost += freq * calculateCycleCost(model as ClaudeModel);
+  }
+
+  return totalCost;
+}
+
+/**
+ * ModelRouter class for stateful model selection with metrics tracking.
+ */
+export class ModelRouter {
+  private readonly config: ModelRoutingConfig;
+  private readonly fallbackRules: FallbackRules;
+  private retryCount: Map<number, number> = new Map();
+
+  constructor(
+    config: ModelRoutingConfig = DEFAULT_ROUTING_CONFIG,
+    fallbackRules: FallbackRules = DEFAULT_FALLBACK_RULES
+  ) {
+    this.config = config;
+    this.fallbackRules = fallbackRules;
+  }
+
+  /**
+   * Select model for a dispatch cycle.
+   */
+  selectForCycle(role: RoleId, actionDescription?: string): ModelSelectionResult {
+    return selectModel(role, actionDescription, this.config);
+  }
+
+  /**
+   * Get fallback model after a failure.
+   */
+  handleFailure(
+    cycle: number,
+    currentModel: ClaudeModel,
+    trigger: FallbackTrigger
+  ): ModelSelectionResult | null {
+    if (!this.config.enableFallback) {
+      return null;
+    }
+
+    const retries = this.retryCount.get(cycle) || 0;
+    const tier = getModelTier(currentModel);
+    const maxRetries =
+      tier === 'fast' ? this.fallbackRules.haiku.maxRetries : this.fallbackRules.sonnet.maxRetries;
+
+    if (retries >= maxRetries) {
+      return null;
+    }
+
+    const fallback = getFallbackModel(currentModel, trigger, this.fallbackRules);
+    if (fallback) {
+      this.retryCount.set(cycle, retries + 1);
+    }
+
+    return fallback;
+  }
+
+  /**
+   * Get the current configuration.
+   */
+  getConfig(): ModelRoutingConfig {
+    return this.config;
+  }
+
+  /**
+   * Get projected cost statistics.
+   */
+  getProjectedStats(): {
+    avgCostPerCycle: number;
+    distribution: Record<ClaudeModel, number>;
+    savingsVsAllSonnet: number;
+  } {
+    const avgCost = calculateProjectedCycleCost(this.config);
+    const allSonnetCost = calculateCycleCost('claude-3-5-sonnet-20241022');
+    const savings = (1 - avgCost / allSonnetCost) * 100;
+
+    return {
+      avgCostPerCycle: avgCost,
+      distribution: getModelDistribution(this.config),
+      savingsVsAllSonnet: savings,
+    };
+  }
+}

--- a/packages/core/src/models/types.ts
+++ b/packages/core/src/models/types.ts
@@ -1,0 +1,205 @@
+/**
+ * Model Routing Types
+ *
+ * Type definitions for role-based LLM model selection.
+ * Based on Research C723: LLM Model Selection for Role-Based Routing.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Supported Anthropic Claude models for dispatch cycles.
+ */
+export type ClaudeModel =
+  | 'claude-3-5-haiku-20241022'
+  | 'claude-3-5-sonnet-20241022'
+  | 'claude-3-opus-20240229';
+
+/**
+ * Model tier classification for cost/quality tradeoffs.
+ */
+export type ModelTier = 'fast' | 'balanced' | 'premium';
+
+/**
+ * Role identifiers that can have model overrides.
+ */
+export type RoleId =
+  | 'ceo'
+  | 'growth'
+  | 'research'
+  | 'frontier'
+  | 'product'
+  | 'scrum'
+  | 'qa'
+  | 'engineering'
+  | 'ops'
+  | 'design'
+  | 'evangelist';
+
+/**
+ * Action types that affect model selection.
+ * Used for role-specific action routing (e.g., Ops merge vs infra).
+ */
+export type ActionType =
+  // Ops actions
+  | 'merge'
+  | 'triage'
+  | 'infra'
+  // CEO actions
+  | 'endorse'
+  | 'pivot'
+  | 'adr'
+  | 'launch'
+  // Generic
+  | 'default';
+
+/**
+ * Task complexity levels for model selection.
+ */
+export type TaskComplexity = 'routine' | 'standard' | 'complex' | 'critical';
+
+/**
+ * Model metadata including cost and capabilities.
+ */
+export interface ModelInfo {
+  /** Model identifier */
+  readonly model: ClaudeModel;
+  /** Model tier classification */
+  readonly tier: ModelTier;
+  /** Cost per million input tokens (USD) */
+  readonly inputCostPerMillion: number;
+  /** Cost per million output tokens (USD) */
+  readonly outputCostPerMillion: number;
+  /** Maximum context window size */
+  readonly contextWindow: number;
+  /** Task complexities this model handles well */
+  readonly suitableFor: readonly TaskComplexity[];
+}
+
+/**
+ * Role-specific model override configuration.
+ */
+export interface RoleModelOverride {
+  /** Default model for this role */
+  readonly default: ClaudeModel;
+  /** Action-specific overrides (optional, partial - only specify actions that need overrides) */
+  readonly actions?: Readonly<Partial<Record<ActionType, ClaudeModel>>>;
+}
+
+/**
+ * Complete model routing configuration.
+ */
+export interface ModelRoutingConfig {
+  /** Default model when no override applies */
+  readonly default: ClaudeModel;
+  /** Role-specific overrides */
+  readonly roleOverrides: Readonly<Partial<Record<RoleId, ClaudeModel | RoleModelOverride>>>;
+  /** Roles that should never be downgraded to fast tier */
+  readonly complexRoles: readonly RoleId[];
+  /** Enable fallback escalation on validation failure */
+  readonly enableFallback: boolean;
+}
+
+/**
+ * Fallback configuration for handling model failures.
+ */
+export interface FallbackConfig {
+  /** Model to fall back to */
+  readonly fallbackTo: ClaudeModel;
+  /** Conditions that trigger fallback */
+  readonly triggerOn: readonly FallbackTrigger[];
+  /** Maximum retry attempts */
+  readonly maxRetries: number;
+}
+
+/**
+ * Conditions that can trigger a fallback to a higher-tier model.
+ */
+export type FallbackTrigger =
+  | 'validation_failure'
+  | 'incomplete_output'
+  | 'format_error'
+  | 'reasoning_failure'
+  | 'critical_task';
+
+/**
+ * Fallback rules for each model tier.
+ */
+export interface FallbackRules {
+  /** Haiku fallback configuration */
+  readonly haiku: FallbackConfig;
+  /** Sonnet fallback configuration */
+  readonly sonnet: FallbackConfig;
+}
+
+/**
+ * Result of model selection including the model and reasoning.
+ */
+export interface ModelSelectionResult {
+  /** Selected model */
+  readonly model: ClaudeModel;
+  /** Tier of selected model */
+  readonly tier: ModelTier;
+  /** Why this model was selected */
+  readonly reason: string;
+  /** Estimated cost per cycle (USD) */
+  readonly estimatedCostPerCycle: number;
+  /** Whether this is a fallback selection */
+  readonly isFallback: boolean;
+  /** Original model if this is a fallback */
+  readonly originalModel?: ClaudeModel;
+}
+
+/**
+ * Dispatch output structure for validation.
+ */
+export interface DispatchOutput {
+  /** Action description (required, min 10 chars) */
+  readonly action: string;
+  /** Role state update */
+  readonly roleState: string;
+  /** Memory bank updates */
+  readonly memoryUpdates: readonly string[];
+  /** Commit message if code change */
+  readonly commitMessage?: string;
+  /** PR URL if PR created */
+  readonly prUrl?: string;
+}
+
+/**
+ * Validation result for dispatch output.
+ */
+export interface ValidationResult {
+  /** Whether validation passed */
+  readonly valid: boolean;
+  /** Error message if validation failed */
+  readonly error?: string;
+  /** Suggested fallback trigger if validation failed */
+  readonly suggestedTrigger?: FallbackTrigger;
+}
+
+/**
+ * Model usage metrics for a cycle.
+ */
+export interface CycleModelMetrics {
+  /** Cycle number */
+  readonly cycle: number;
+  /** Role that executed */
+  readonly role: RoleId;
+  /** Model used */
+  readonly model: ClaudeModel;
+  /** Action type if relevant */
+  readonly actionType?: ActionType;
+  /** Input tokens used */
+  readonly inputTokens: number;
+  /** Output tokens used */
+  readonly outputTokens: number;
+  /** Total cost (USD) */
+  readonly cost: number;
+  /** Whether fallback was used */
+  readonly usedFallback: boolean;
+  /** Validation result */
+  readonly validationPassed: boolean;
+  /** Timestamp */
+  readonly timestamp: string;
+}

--- a/packages/core/src/models/validation.ts
+++ b/packages/core/src/models/validation.ts
@@ -1,0 +1,215 @@
+/**
+ * Dispatch Output Validation
+ *
+ * Validates dispatch cycle outputs to ensure quality.
+ * Used for fallback escalation decisions.
+ *
+ * @packageDocumentation
+ */
+
+import type { DispatchOutput, ValidationResult, RoleId } from './types.js';
+
+/**
+ * Minimum action description length.
+ */
+export const MIN_ACTION_LENGTH = 10;
+
+/**
+ * Maximum action description length (sanity check).
+ */
+export const MAX_ACTION_LENGTH = 500;
+
+/**
+ * Required keywords that should appear in action descriptions.
+ */
+export const ROLE_ACTION_KEYWORDS: Readonly<Record<RoleId, readonly string[]>> = {
+  ceo: ['strategy', 'decision', 'endorse', 'pivot', 'direction', 'priority', 'launch'],
+  growth: ['marketing', 'channel', 'acquisition', 'growth', 'campaign', 'outreach', 'funnel'],
+  research: ['research', 'analysis', 'finding', 'study', 'benchmark', 'paper', 'model'],
+  frontier: ['prototype', 'architecture', 'platform', 'infrastructure', 'innovation', 'system'],
+  product: ['spec', 'requirement', 'feature', 'user', 'acceptance', 'criteria', 'backlog'],
+  scrum: ['retro', 'sprint', 'tracking', 'velocity', 'coordination', 'standup', 'blocked'],
+  qa: ['test', 'coverage', 'quality', 'bug', 'regression', 'validation', 'gate'],
+  engineering: ['implement', 'code', 'pr', 'fix', 'feature', 'module', 'function', 'test'],
+  ops: ['ci', 'merge', 'deploy', 'workflow', 'rule', 'standard', 'review', 'triage'],
+  design: ['design', 'ux', 'interface', 'api', 'spec', 'diagram', 'flow', 'experience'],
+  evangelist: ['outreach', 'integration', 'pr', 'repo', 'adoption', 'external', 'case study'],
+} as const;
+
+/**
+ * Validate a dispatch output for completeness and quality.
+ *
+ * @param output - The dispatch output to validate
+ * @param role - The role that generated the output
+ * @returns Validation result with error details if failed
+ */
+export function validateDispatchOutput(output: DispatchOutput, role: RoleId): ValidationResult {
+  // Check action exists and meets length requirements
+  if (!output.action) {
+    return {
+      valid: false,
+      error: 'Missing action description',
+      suggestedTrigger: 'incomplete_output',
+    };
+  }
+
+  if (output.action.length < MIN_ACTION_LENGTH) {
+    return {
+      valid: false,
+      error: `Action too short (${output.action.length} chars, min ${MIN_ACTION_LENGTH})`,
+      suggestedTrigger: 'incomplete_output',
+    };
+  }
+
+  if (output.action.length > MAX_ACTION_LENGTH) {
+    return {
+      valid: false,
+      error: `Action too long (${output.action.length} chars, max ${MAX_ACTION_LENGTH})`,
+      suggestedTrigger: 'format_error',
+    };
+  }
+
+  // Check role state exists
+  if (!output.roleState || output.roleState.trim().length === 0) {
+    return {
+      valid: false,
+      error: 'Missing role state update',
+      suggestedTrigger: 'incomplete_output',
+    };
+  }
+
+  // Check memory updates exist
+  if (!output.memoryUpdates || output.memoryUpdates.length === 0) {
+    return {
+      valid: false,
+      error: 'Missing memory updates',
+      suggestedTrigger: 'incomplete_output',
+    };
+  }
+
+  // Check for role-relevant keywords (warning, not failure)
+  const keywords = ROLE_ACTION_KEYWORDS[role];
+  const actionLower = output.action.toLowerCase();
+  const hasRelevantKeyword = keywords.some((keyword) => actionLower.includes(keyword));
+
+  if (!hasRelevantKeyword) {
+    // This is a soft warning - action may still be valid but potentially off-topic
+    console.warn(
+      `[ModelRouter] Action may be off-topic for ${role}: no keywords found. ` +
+        `Expected one of: ${keywords.join(', ')}`
+    );
+  }
+
+  // Validate PR URL format if present
+  if (output.prUrl && !isValidPrUrl(output.prUrl)) {
+    return {
+      valid: false,
+      error: `Invalid PR URL format: ${output.prUrl}`,
+      suggestedTrigger: 'format_error',
+    };
+  }
+
+  // Validate commit message format if present
+  if (output.commitMessage && !isValidCommitMessage(output.commitMessage)) {
+    return {
+      valid: false,
+      error: 'Commit message does not follow conventional format',
+      suggestedTrigger: 'format_error',
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Check if a URL looks like a valid GitHub PR URL.
+ */
+export function isValidPrUrl(url: string): boolean {
+  // Basic validation - should be a GitHub PR URL
+  const prUrlPattern = /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+$/;
+  return prUrlPattern.test(url);
+}
+
+/**
+ * Check if a commit message follows conventional commit format.
+ */
+export function isValidCommitMessage(message: string): boolean {
+  // Conventional commit: type(scope): description
+  const conventionalPattern = /^(feat|fix|docs|style|refactor|test|chore|ci|perf|build)\([^)]+\): .+$/;
+  // Also allow type: description (without scope)
+  const simplePattern = /^(feat|fix|docs|style|refactor|test|chore|ci|perf|build): .+$/;
+
+  return conventionalPattern.test(message) || simplePattern.test(message);
+}
+
+/**
+ * Parse a dispatch output from raw LLM response.
+ * This is a best-effort parser for structured output.
+ *
+ * @param rawOutput - Raw text output from the LLM
+ * @param role - The role that generated the output
+ * @returns Parsed dispatch output or null if parsing failed
+ */
+export function parseDispatchOutput(rawOutput: string, role: RoleId): DispatchOutput | null {
+  try {
+    // Try JSON parse first
+    const parsed = JSON.parse(rawOutput);
+    if (parsed.action && parsed.roleState && parsed.memoryUpdates) {
+      return parsed as DispatchOutput;
+    }
+  } catch {
+    // Not JSON, try to extract from structured text
+  }
+
+  // Extract action from markdown-style output
+  const actionMatch = rawOutput.match(/##?\s*Action[:\s]*(.+?)(?=##|$)/is);
+  const roleStateMatch = rawOutput.match(/##?\s*Role State[:\s]*(.+?)(?=##|$)/is);
+  const memoryMatch = rawOutput.match(/##?\s*Memory Updates?[:\s]*(.+?)(?=##|$)/is);
+
+  if (actionMatch?.[1] && roleStateMatch?.[1]) {
+    const memoryUpdates =
+      memoryMatch?.[1]
+        ? memoryMatch[1]
+            .split(/[-*•]\s*/)
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0)
+        : [`Updated ${role} state`];
+
+    return {
+      action: actionMatch[1].trim(),
+      roleState: roleStateMatch[1].trim(),
+      memoryUpdates,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Calculate a quality score for a dispatch output (0-100).
+ * Higher scores indicate better quality.
+ */
+export function calculateQualityScore(output: DispatchOutput, role: RoleId): number {
+  let score = 0;
+
+  // Base score for having required fields
+  if (output.action) score += 25;
+  if (output.roleState) score += 25;
+  if (output.memoryUpdates?.length > 0) score += 25;
+
+  // Length quality
+  if (output.action.length >= 50) score += 10;
+  if (output.action.length >= 100) score += 5;
+
+  // Keyword relevance
+  const keywords = ROLE_ACTION_KEYWORDS[role];
+  const actionLower = output.action.toLowerCase();
+  const keywordMatches = keywords.filter((keyword) => actionLower.includes(keyword)).length;
+  score += Math.min(keywordMatches * 5, 15);
+
+  // Has PR or commit (extra credit for code work)
+  if (output.prUrl) score += 5;
+  if (output.commitMessage) score += 5;
+
+  return Math.min(score, 100);
+}

--- a/packages/core/tests/models/router.test.ts
+++ b/packages/core/tests/models/router.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  selectModel,
+  getFallbackModel,
+  calculateCycleCost,
+  getModelTier,
+  isComplexRole,
+  inferActionType,
+  getModelDistribution,
+  calculateProjectedCycleCost,
+  ModelRouter,
+  MODEL_INFO,
+  DEFAULT_ROUTING_CONFIG,
+} from '../../src/models/router.js';
+import type { ClaudeModel } from '../../src/models/types.js';
+
+describe('ModelRouter', () => {
+  describe('selectModel', () => {
+    it('should select Haiku for Scrum role', () => {
+      const result = selectModel('scrum');
+      expect(result.model).toBe('claude-3-5-haiku-20241022');
+      expect(result.tier).toBe('fast');
+      expect(result.isFallback).toBe(false);
+    });
+
+    it('should select Haiku for Evangelist role', () => {
+      const result = selectModel('evangelist');
+      expect(result.model).toBe('claude-3-5-haiku-20241022');
+      expect(result.tier).toBe('fast');
+    });
+
+    it('should select Sonnet as default for Engineering role', () => {
+      const result = selectModel('engineering');
+      expect(result.model).toBe('claude-3-5-sonnet-20241022');
+      expect(result.tier).toBe('balanced');
+    });
+
+    it('should select Sonnet as default for Research role', () => {
+      const result = selectModel('research');
+      expect(result.model).toBe('claude-3-5-sonnet-20241022');
+    });
+
+    it('should select Sonnet as default for Frontier role', () => {
+      const result = selectModel('frontier');
+      expect(result.model).toBe('claude-3-5-sonnet-20241022');
+    });
+
+    it('should select Sonnet for Design role', () => {
+      const result = selectModel('design');
+      expect(result.model).toBe('claude-3-5-sonnet-20241022');
+    });
+
+    it('should select Haiku for Ops merge action', () => {
+      const result = selectModel('ops', 'PR #159 merged — Container MVP Foundation');
+      expect(result.model).toBe('claude-3-5-haiku-20241022');
+      expect(result.reason).toContain('merge');
+    });
+
+    it('should select Haiku for Ops triage action', () => {
+      const result = selectModel('ops', 'PR triage and review');
+      expect(result.model).toBe('claude-3-5-haiku-20241022');
+    });
+
+    it('should select Sonnet for Ops infra action', () => {
+      const result = selectModel('ops', 'Update CI workflow');
+      expect(result.model).toBe('claude-3-5-sonnet-20241022');
+      expect(result.reason).toContain('infra');
+    });
+
+    it('should select Opus for CEO strategic endorsement', () => {
+      const result = selectModel('ceo', 'Strategic cost strategy endorsement');
+      expect(result.model).toBe('claude-3-opus-20240229');
+      expect(result.tier).toBe('premium');
+    });
+
+    it('should select Opus for CEO pivot decision', () => {
+      const result = selectModel('ceo', 'Strategic pivot to Bootstrap via SaaS');
+      expect(result.model).toBe('claude-3-opus-20240229');
+    });
+
+    it('should select Opus for CEO ADR decision', () => {
+      const result = selectModel('ceo', 'Architecture Decision Record for new system');
+      expect(result.model).toBe('claude-3-opus-20240229');
+    });
+
+    it('should select Opus for CEO launch decision', () => {
+      const result = selectModel('ceo', 'Launch go/no-go decision for v1.0');
+      expect(result.model).toBe('claude-3-opus-20240229');
+    });
+
+    it('should select Sonnet for CEO status update', () => {
+      const result = selectModel('ceo', 'Weekly status review and sync');
+      expect(result.model).toBe('claude-3-5-sonnet-20241022');
+    });
+
+    it('should prevent complex roles from using Haiku even if configured', () => {
+      // Create a custom config that tries to route engineering to Haiku
+      const badConfig = {
+        ...DEFAULT_ROUTING_CONFIG,
+        roleOverrides: {
+          ...DEFAULT_ROUTING_CONFIG.roleOverrides,
+          engineering: 'claude-3-5-haiku-20241022' as ClaudeModel,
+        },
+      };
+
+      const result = selectModel('engineering', undefined, badConfig);
+      // Should upgrade to Sonnet because engineering is a complex role
+      expect(result.model).toBe('claude-3-5-sonnet-20241022');
+      expect(result.reason).toContain('complex role');
+    });
+  });
+
+  describe('inferActionType', () => {
+    it('should detect merge action for Ops', () => {
+      expect(inferActionType('ops', 'PR #159 merged')).toBe('merge');
+    });
+
+    it('should detect triage action for Ops', () => {
+      expect(inferActionType('ops', 'PR review and triage')).toBe('triage');
+    });
+
+    it('should detect infra action for Ops', () => {
+      expect(inferActionType('ops', 'Update CI workflow for npm')).toBe('infra');
+    });
+
+    it('should detect endorse action for CEO', () => {
+      expect(inferActionType('ceo', 'Cost strategy endorsement')).toBe('endorse');
+    });
+
+    it('should detect pivot action for CEO', () => {
+      expect(inferActionType('ceo', 'Strategic pivot decision')).toBe('pivot');
+    });
+
+    it('should return default for unrecognized actions', () => {
+      expect(inferActionType('engineering', 'Implement new feature')).toBe('default');
+    });
+  });
+
+  describe('getFallbackModel', () => {
+    it('should fallback Haiku to Sonnet on validation failure', () => {
+      const result = getFallbackModel('claude-3-5-haiku-20241022', 'validation_failure');
+      expect(result).toBeDefined();
+      if (result) {
+        expect(result.model).toBe('claude-3-5-sonnet-20241022');
+        expect(result.isFallback).toBe(true);
+        expect(result.originalModel).toBe('claude-3-5-haiku-20241022');
+      }
+    });
+
+    it('should fallback Haiku to Sonnet on incomplete output', () => {
+      const result = getFallbackModel('claude-3-5-haiku-20241022', 'incomplete_output');
+      expect(result).toBeDefined();
+      if (result) {
+        expect(result.model).toBe('claude-3-5-sonnet-20241022');
+      }
+    });
+
+    it('should fallback Sonnet to Opus on critical task', () => {
+      const result = getFallbackModel('claude-3-5-sonnet-20241022', 'critical_task');
+      expect(result).toBeDefined();
+      if (result) {
+        expect(result.model).toBe('claude-3-opus-20240229');
+        expect(result.tier).toBe('premium');
+      }
+    });
+
+    it('should not fallback Opus (already premium tier)', () => {
+      const result = getFallbackModel('claude-3-opus-20240229', 'validation_failure');
+      expect(result).toBeNull();
+    });
+
+    it('should not fallback Haiku on non-matching trigger', () => {
+      const result = getFallbackModel('claude-3-5-haiku-20241022', 'critical_task');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('calculateCycleCost', () => {
+    it('should calculate Haiku cost correctly', () => {
+      const cost = calculateCycleCost('claude-3-5-haiku-20241022');
+      // (5000/1M * 0.8) + (2000/1M * 4.0) + (1000/1M * 0.8) = 0.004 + 0.008 + 0.0008 = 0.0128
+      expect(cost).toBeCloseTo(0.0128, 4);
+    });
+
+    it('should calculate Sonnet cost correctly', () => {
+      const cost = calculateCycleCost('claude-3-5-sonnet-20241022');
+      // (5000/1M * 3.0) + (2000/1M * 15.0) + (1000/1M * 3.0) = 0.015 + 0.03 + 0.003 = 0.048
+      expect(cost).toBeCloseTo(0.048, 4);
+    });
+
+    it('should calculate Opus cost correctly', () => {
+      const cost = calculateCycleCost('claude-3-opus-20240229');
+      // (5000/1M * 15.0) + (2000/1M * 75.0) + (1000/1M * 15.0) = 0.075 + 0.15 + 0.015 = 0.24
+      expect(cost).toBeCloseTo(0.24, 4);
+    });
+
+    it('should show Haiku is cheapest', () => {
+      const haiku = calculateCycleCost('claude-3-5-haiku-20241022');
+      const sonnet = calculateCycleCost('claude-3-5-sonnet-20241022');
+      const opus = calculateCycleCost('claude-3-opus-20240229');
+
+      expect(haiku).toBeLessThan(sonnet);
+      expect(sonnet).toBeLessThan(opus);
+    });
+  });
+
+  describe('getModelTier', () => {
+    it('should return fast for Haiku', () => {
+      expect(getModelTier('claude-3-5-haiku-20241022')).toBe('fast');
+    });
+
+    it('should return balanced for Sonnet', () => {
+      expect(getModelTier('claude-3-5-sonnet-20241022')).toBe('balanced');
+    });
+
+    it('should return premium for Opus', () => {
+      expect(getModelTier('claude-3-opus-20240229')).toBe('premium');
+    });
+  });
+
+  describe('isComplexRole', () => {
+    it('should return true for Engineering', () => {
+      expect(isComplexRole('engineering')).toBe(true);
+    });
+
+    it('should return true for Research', () => {
+      expect(isComplexRole('research')).toBe(true);
+    });
+
+    it('should return true for Frontier', () => {
+      expect(isComplexRole('frontier')).toBe(true);
+    });
+
+    it('should return true for Design', () => {
+      expect(isComplexRole('design')).toBe(true);
+    });
+
+    it('should return false for Scrum', () => {
+      expect(isComplexRole('scrum')).toBe(false);
+    });
+
+    it('should return false for Evangelist', () => {
+      expect(isComplexRole('evangelist')).toBe(false);
+    });
+
+    it('should return false for Ops', () => {
+      expect(isComplexRole('ops')).toBe(false);
+    });
+  });
+
+  describe('getModelDistribution', () => {
+    it('should sum to approximately 1', () => {
+      const dist = getModelDistribution();
+      const total = Object.values(dist).reduce((a, b) => a + b, 0);
+      expect(total).toBeCloseTo(1, 1);
+    });
+
+    it('should have significant Haiku usage', () => {
+      const dist = getModelDistribution();
+      // Scrum + Evangelist = ~19% base, plus some Ops merge/triage
+      expect(dist['claude-3-5-haiku-20241022']).toBeGreaterThan(0.15);
+    });
+
+    it('should have majority Sonnet usage', () => {
+      const dist = getModelDistribution();
+      expect(dist['claude-3-5-sonnet-20241022']).toBeGreaterThan(0.5);
+    });
+
+    it('should have minimal Opus usage', () => {
+      const dist = getModelDistribution();
+      // Only CEO strategic actions, which are rare
+      expect(dist['claude-3-opus-20240229']).toBeLessThan(0.1);
+    });
+  });
+
+  describe('calculateProjectedCycleCost', () => {
+    it('should be less than all-Sonnet baseline', () => {
+      const projected = calculateProjectedCycleCost();
+      const allSonnet = calculateCycleCost('claude-3-5-sonnet-20241022');
+
+      expect(projected).toBeLessThan(allSonnet);
+    });
+
+    it('should be more than all-Haiku baseline', () => {
+      const projected = calculateProjectedCycleCost();
+      const allHaiku = calculateCycleCost('claude-3-5-haiku-20241022');
+
+      expect(projected).toBeGreaterThan(allHaiku);
+    });
+  });
+
+  describe('ModelRouter class', () => {
+    let router: ModelRouter;
+
+    beforeEach(() => {
+      router = new ModelRouter();
+    });
+
+    it('should select model for cycle', () => {
+      const result = router.selectForCycle('scrum');
+      expect(result.model).toBe('claude-3-5-haiku-20241022');
+    });
+
+    it('should handle failure with fallback', () => {
+      const fallback = router.handleFailure(1, 'claude-3-5-haiku-20241022', 'validation_failure');
+      expect(fallback).toBeDefined();
+      if (fallback) {
+        expect(fallback.model).toBe('claude-3-5-sonnet-20241022');
+      }
+    });
+
+    it('should respect max retries', () => {
+      // First failure
+      const fallback1 = router.handleFailure(1, 'claude-3-5-haiku-20241022', 'validation_failure');
+      expect(fallback1).not.toBeNull();
+
+      // Second failure on same cycle - should return null (max retries = 1)
+      const fallback2 = router.handleFailure(1, 'claude-3-5-sonnet-20241022', 'validation_failure');
+      expect(fallback2).toBeNull();
+    });
+
+    it('should return config', () => {
+      const config = router.getConfig();
+      expect(config.default).toBe('claude-3-5-sonnet-20241022');
+    });
+
+    it('should return projected stats', () => {
+      const stats = router.getProjectedStats();
+      expect(stats.avgCostPerCycle).toBeGreaterThan(0);
+      expect(stats.distribution).toBeDefined();
+      expect(stats.savingsVsAllSonnet).toBeGreaterThan(0);
+    });
+
+    it('should disable fallback when configured', () => {
+      const noFallbackRouter = new ModelRouter({
+        ...DEFAULT_ROUTING_CONFIG,
+        enableFallback: false,
+      });
+
+      const fallback = noFallbackRouter.handleFailure(
+        1,
+        'claude-3-5-haiku-20241022',
+        'validation_failure'
+      );
+      expect(fallback).toBeNull();
+    });
+  });
+
+  describe('MODEL_INFO', () => {
+    it('should have correct Haiku info', () => {
+      const haiku = MODEL_INFO['claude-3-5-haiku-20241022'];
+      expect(haiku.tier).toBe('fast');
+      expect(haiku.inputCostPerMillion).toBe(0.8);
+      expect(haiku.contextWindow).toBe(200_000);
+    });
+
+    it('should have correct Sonnet info', () => {
+      const sonnet = MODEL_INFO['claude-3-5-sonnet-20241022'];
+      expect(sonnet.tier).toBe('balanced');
+      expect(sonnet.inputCostPerMillion).toBe(3.0);
+    });
+
+    it('should have correct Opus info', () => {
+      const opus = MODEL_INFO['claude-3-opus-20240229'];
+      expect(opus.tier).toBe('premium');
+      expect(opus.inputCostPerMillion).toBe(15.0);
+    });
+  });
+});

--- a/packages/core/tests/models/validation.test.ts
+++ b/packages/core/tests/models/validation.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateDispatchOutput,
+  isValidPrUrl,
+  isValidCommitMessage,
+  parseDispatchOutput,
+  calculateQualityScore,
+} from '../../src/models/validation.js';
+import type { DispatchOutput } from '../../src/models/types.js';
+
+describe('Validation', () => {
+  describe('validateDispatchOutput', () => {
+    const validOutput: DispatchOutput = {
+      action: '🌌 Implemented model router for role-based LLM selection',
+      roleState: 'Last: Model router implementation. Next: Integration with dispatch.',
+      memoryUpdates: ['Updated Current Status', 'Updated Frontier state'],
+    };
+
+    it('should pass valid output', () => {
+      const result = validateDispatchOutput(validOutput, 'frontier');
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should fail on missing action', () => {
+      const output = { ...validOutput, action: '' };
+      const result = validateDispatchOutput(output, 'frontier');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Missing action');
+      expect(result.suggestedTrigger).toBe('incomplete_output');
+    });
+
+    it('should fail on short action', () => {
+      const output = { ...validOutput, action: 'Short' };
+      const result = validateDispatchOutput(output, 'frontier');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('too short');
+    });
+
+    it('should fail on missing role state', () => {
+      const output = { ...validOutput, roleState: '' };
+      const result = validateDispatchOutput(output, 'frontier');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('role state');
+    });
+
+    it('should fail on empty memory updates', () => {
+      const output = { ...validOutput, memoryUpdates: [] };
+      const result = validateDispatchOutput(output, 'frontier');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('memory updates');
+    });
+
+    it('should fail on invalid PR URL', () => {
+      const output = { ...validOutput, prUrl: 'not-a-url' };
+      const result = validateDispatchOutput(output, 'engineering');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('PR URL');
+      expect(result.suggestedTrigger).toBe('format_error');
+    });
+
+    it('should fail on non-conventional commit message', () => {
+      const output = { ...validOutput, commitMessage: 'added some stuff' };
+      const result = validateDispatchOutput(output, 'engineering');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('conventional');
+    });
+
+    it('should pass with valid PR URL', () => {
+      const output = {
+        ...validOutput,
+        prUrl: 'https://github.com/ishan190425/autonomous-dev-agents/pull/160',
+      };
+      const result = validateDispatchOutput(output, 'engineering');
+      expect(result.valid).toBe(true);
+    });
+
+    it('should pass with valid conventional commit', () => {
+      const output = {
+        ...validOutput,
+        commitMessage: 'feat(core): add model router module',
+      };
+      const result = validateDispatchOutput(output, 'engineering');
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('isValidPrUrl', () => {
+    it('should accept valid GitHub PR URL', () => {
+      expect(isValidPrUrl('https://github.com/user/repo/pull/123')).toBe(true);
+    });
+
+    it('should accept valid org PR URL', () => {
+      expect(isValidPrUrl('https://github.com/ishan190425/autonomous-dev-agents/pull/159')).toBe(
+        true
+      );
+    });
+
+    it('should reject non-GitHub URLs', () => {
+      expect(isValidPrUrl('https://gitlab.com/user/repo/pull/123')).toBe(false);
+    });
+
+    it('should reject malformed URLs', () => {
+      expect(isValidPrUrl('github.com/user/repo/pull/123')).toBe(false);
+    });
+
+    it('should reject issue URLs', () => {
+      expect(isValidPrUrl('https://github.com/user/repo/issues/123')).toBe(false);
+    });
+
+    it('should reject PR URLs without number', () => {
+      expect(isValidPrUrl('https://github.com/user/repo/pull/')).toBe(false);
+    });
+  });
+
+  describe('isValidCommitMessage', () => {
+    it('should accept feat with scope', () => {
+      expect(isValidCommitMessage('feat(core): add model router')).toBe(true);
+    });
+
+    it('should accept fix with scope', () => {
+      expect(isValidCommitMessage('fix(cli): resolve dispatch bug')).toBe(true);
+    });
+
+    it('should accept docs with scope', () => {
+      expect(isValidCommitMessage('docs(agents): update DISPATCH.md')).toBe(true);
+    });
+
+    it('should accept chore with scope', () => {
+      expect(isValidCommitMessage('chore(deps): update dependencies')).toBe(true);
+    });
+
+    it('should accept test without scope', () => {
+      expect(isValidCommitMessage('test: add router tests')).toBe(true);
+    });
+
+    it('should accept ci without scope', () => {
+      expect(isValidCommitMessage('ci: update workflow')).toBe(true);
+    });
+
+    it('should reject non-conventional messages', () => {
+      expect(isValidCommitMessage('Added some new features')).toBe(false);
+    });
+
+    it('should reject missing description', () => {
+      expect(isValidCommitMessage('feat(core):')).toBe(false);
+    });
+
+    it('should reject unknown type', () => {
+      expect(isValidCommitMessage('update(core): something')).toBe(false);
+    });
+  });
+
+  describe('parseDispatchOutput', () => {
+    it('should parse JSON output', () => {
+      const json = JSON.stringify({
+        action: 'Test action description here',
+        roleState: 'Current state update',
+        memoryUpdates: ['Update 1', 'Update 2'],
+      });
+
+      const result = parseDispatchOutput(json, 'engineering');
+      expect(result).toBeDefined();
+      if (result) {
+        expect(result.action).toBe('Test action description here');
+        expect(result.memoryUpdates).toHaveLength(2);
+      }
+    });
+
+    it('should parse markdown-style output', () => {
+      const markdown = `
+## Action
+Implemented new feature for the system
+
+## Role State
+Last: Did the thing. Next: Do another thing.
+
+## Memory Updates
+- Updated Current Status
+- Updated Role State
+      `;
+
+      const result = parseDispatchOutput(markdown, 'engineering');
+      expect(result).toBeDefined();
+      if (result) {
+        expect(result.action).toContain('Implemented new feature');
+        expect(result.roleState).toContain('Last: Did the thing');
+        expect(result.memoryUpdates.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should return null for unparseable output', () => {
+      const result = parseDispatchOutput('Just some random text', 'engineering');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('calculateQualityScore', () => {
+    it('should score complete output highly', () => {
+      const output: DispatchOutput = {
+        action: '🌌 Implemented model router for role-based LLM selection with infrastructure patterns',
+        roleState: 'Last: Model router implementation. Next: Integration.',
+        memoryUpdates: ['Updated Current Status', 'Updated Frontier state'],
+        prUrl: 'https://github.com/user/repo/pull/160',
+        commitMessage: 'feat(core): add model router',
+      };
+
+      const score = calculateQualityScore(output, 'frontier');
+      expect(score).toBeGreaterThanOrEqual(90);
+    });
+
+    it('should score minimal output lower', () => {
+      const output: DispatchOutput = {
+        action: 'Did something',
+        roleState: 'Updated',
+        memoryUpdates: ['One update'],
+      };
+
+      const score = calculateQualityScore(output, 'frontier');
+      expect(score).toBeLessThan(80);
+    });
+
+    it('should give bonus for role-relevant keywords', () => {
+      const withKeyword: DispatchOutput = {
+        action: 'Implemented prototype for new platform infrastructure',
+        roleState: 'State update',
+        memoryUpdates: ['Update'],
+      };
+
+      const withoutKeyword: DispatchOutput = {
+        action: 'Did some work on the codebase today',
+        roleState: 'State update',
+        memoryUpdates: ['Update'],
+      };
+
+      const scoreWith = calculateQualityScore(withKeyword, 'frontier');
+      const scoreWithout = calculateQualityScore(withoutKeyword, 'frontier');
+
+      expect(scoreWith).toBeGreaterThan(scoreWithout);
+    });
+
+    it('should cap at 100', () => {
+      const perfectOutput: DispatchOutput = {
+        action:
+          '🌌 Implemented prototype for new platform infrastructure system architecture with innovation and comprehensive testing',
+        roleState: 'Complete state with all details',
+        memoryUpdates: ['Update 1', 'Update 2', 'Update 3'],
+        prUrl: 'https://github.com/user/repo/pull/160',
+        commitMessage: 'feat(core): add amazing feature',
+      };
+
+      const score = calculateQualityScore(perfectOutput, 'frontier');
+      expect(score).toBeLessThanOrEqual(100);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements Research C723 recommendations for cost optimization via role-based model routing.

**Expected savings:** 14% vs all-Sonnet baseline ($0.051 → $0.044/cycle)

## Strategy

| Tier | Models | % of Cycles | Use Cases |
|------|--------|-------------|-----------|
| Fast | Haiku | 35% | Scrum retros, Evangelist outreach, Ops merge/triage |
| Balanced | Sonnet | 62% | Engineering, Research, Frontier, Design, Product, QA, Growth |
| Premium | Opus | 3% | CEO strategic decisions (endorse, pivot, ADR, launch) |

## Features

- `ModelRouter` class with role/action-based selection
- Fallback escalation (Haiku→Sonnet→Opus) on validation failure
- Output validation for dispatch results
- Cost calculation and projection utilities
- 86 unit tests covering all routing scenarios

## Files Changed

| File | Purpose |
|------|---------|
| `packages/core/src/models/types.ts` | Type definitions |
| `packages/core/src/models/router.ts` | Model selection logic |
| `packages/core/src/models/validation.ts` | Output validation |
| `packages/core/src/models/index.ts` | Barrel exports |
| `packages/core/tests/models/` | Unit tests (86 tests) |

## Engineering Handoff

Per Research C723 checklist, this provides:
- [x] TypeScript interfaces for config
- [x] Role-based selection logic
- [x] Action-level routing for Ops/CEO
- [x] Fallback rules with triggers
- [x] Output validation schema
- [x] Cost calculation utilities
- [x] Unit tests (86 passing)

Remaining Engineering tasks:
- [ ] Integrate with `ada dispatch start` (add `--model` flag)
- [ ] Add model used to dispatch completion log
- [ ] Update `ada status` to show model routing config

## Related Issues

Relates to #155 (SaaS Container Phase 1)
Implements Research C723 (LLM Model Selection)

---

🌌 *The Frontier | Head of Platform & Innovation | Cycle 724*