### PR TITLE
fix(cli): extend PATH for gh CLI detection in ada validate

### DIFF
--- a/packages/cli/src/commands/__tests__/validate.test.ts
+++ b/packages/cli/src/commands/__tests__/validate.test.ts
@@ -166,6 +166,13 @@ describe('validate command integration', () => {
       // TODO: Run with --quick
       // Verify SC-3 is not in results
     });
+
+    it.skip('should find gh CLI in extended PATH including /snap/bin', async () => {
+      // The validate command should include /snap/bin, /usr/local/bin, /opt/homebrew/bin
+      // in its PATH when executing gh commands
+      // This ensures gh CLI installed via snap (Ubuntu) or Homebrew (macOS) is found
+      // See issue #165 for original bug report
+    });
   });
 
   describe('SC-4: Memory Persistence', () => {

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -145,17 +145,36 @@ async function validateModelRouting(agentsDir: string): Promise<ValidationResult
 }
 
 /**
+ * Get extended PATH that includes common CLI installation directories.
+ * Handles snap installs on Ubuntu, Homebrew on macOS, etc.
+ */
+function getExtendedPath(): string {
+  const extraPaths = [
+    '/snap/bin',           // Ubuntu snap packages (gh)
+    '/usr/local/bin',      // Homebrew, manual installs
+    '/opt/homebrew/bin',   // Homebrew on Apple Silicon
+  ];
+  return [...(process.env.PATH?.split(':') ?? []), ...extraPaths].join(':');
+}
+
+/**
  * SC-3: Validate GitHub integration — check gh CLI is authenticated
  */
 function validateGitHubIntegration(): ValidationResult {
+  const execEnv = { ...process.env, PATH: getExtendedPath() };
+  
   try {
     // Check if gh CLI is available and authenticated
-    const result = execSync('gh auth status 2>&1', { encoding: 'utf-8', timeout: 10000 });
+    const result = execSync('gh auth status 2>&1', { 
+      encoding: 'utf-8', 
+      timeout: 10000,
+      env: execEnv,
+    });
     
     if (result.includes('Logged in')) {
       // Try a simple API call
       try {
-        execSync('gh api user --jq .login', { encoding: 'utf-8', timeout: 10000 });
+        execSync('gh api user --jq .login', { encoding: 'utf-8', timeout: 10000, env: execEnv });
         return {
           id: 'SC-3',
           name: 'GitHub Integration',


### PR DESCRIPTION
## Summary

Fixes SC-3 GitHub integration check failing when `gh` CLI is installed via snap or Homebrew rather than being in standard PATH.

## Related Issues

Closes #165

## Changes Made

- Add `getExtendedPath()` helper function to include common CLI installation directories:
  - `/snap/bin` — Ubuntu snap packages
  - `/usr/local/bin` — Homebrew, manual installs
  - `/opt/homebrew/bin` — Homebrew on Apple Silicon
- Pass extended PATH to `execSync` calls for `gh auth status` and `gh api` commands
- Add test documentation for PATH fix

## Testing

Before fix:
```
✗ SC-3: GitHub Integration — GitHub CLI not available or not authenticated
    Command failed: gh auth status 2>&1
```

After fix:
```
✓ SC-3: GitHub Integration — GitHub CLI authenticated and API accessible
```

Full validation passes:
```
🔍 Phase 2 Dogfooding Validation
   Checking all 6 success criteria (SC-1 through SC-6)

  ✓ SC-1: Dispatch Lifecycle — Cycle 748 completed successfully
  ✓ SC-2: Model Routing — Model routing enabled  
  ✓ SC-3: GitHub Integration — GitHub CLI authenticated and API accessible
  ✓ SC-4: Memory Persistence — Memory bank vunknown up to date
  ○ SC-5: Cost Savings — No cycle metrics available
  ✓ SC-6: Consecutive Cycles — 10 cycles, last 5 successful

   5 passed, 1 skipped

   ✅ GO/NO-GO: Ready for launch!
```

## Priority

**P1** — Unblocks Phase 2 dogfooding Day 1 validation (Feb 17)

## Author

🔍 QA (C749)