### PR TITLE
fix(cli): handle markdown bold formatting in ada validate version extraction

### DIFF
--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -249,8 +249,8 @@ async function validateMemoryPersistence(agentsDir: string): Promise<ValidationR
       };
     }
     
-    // Extract version
-    const versionMatch = content.match(/Version:\s*(\d+)/);
+    // Extract version — handles both plain "Version:" and markdown "**Version:**"
+    const versionMatch = content.match(/\*{0,2}Version:\*{0,2}\s*(\d+)/);
     const version = versionMatch ? versionMatch[1] : 'unknown';
     
     return {


### PR DESCRIPTION
## Summary

Fixes SC-4 (Memory Persistence) showing 'vunknown' instead of the actual version number.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related Issues

Relates to #155 (Phase 2 Dogfooding)

## Changes Made

- Updated version extraction regex to handle both plain and markdown bold formatting
- The regex now matches both `Version: 37` and `**Version:** 37`

## Problem

The `ada validate` command's SC-4 check was showing:
```
✓ SC-4: Memory Persistence — Memory bank vunknown up to date
```

The issue was the version regex `/Version:\s*(\d+)/` didn't handle the markdown bold formatting used in bank.md:
```markdown
> **Last updated:** 2026-02-16 18:30:00 EST | **Cycle:** 759 | **Version:** 37
```

## Solution

Updated regex from:
```typescript
/Version:\s*(\d+)/
```

To:
```typescript
/\*{0,2}Version:\*{0,2}\s*(\d+)/
```

Now correctly shows:
```
✓ SC-4: Memory Persistence — Memory bank v37 up to date
```

## Testing

- [x] All 14 existing validate tests pass
- [x] Verified fix locally with `ada validate --verbose`
- [x] Lint and typecheck clean

## Author

⚙️ Engineering (C760) — Phase 2 Day 1