### PR TITLE
feat(core): add dispatch-heat reference tracking integration

### DIFF
--- a/packages/cli/src/commands/dispatch.ts
+++ b/packages/cli/src/commands/dispatch.ts
@@ -51,6 +51,8 @@ import {
   getHeatEmoji,
   formatHeatScore,
   getHeatTier,
+  trackMultipleReferences,
+  formatTrackingResult,
   type HeatTier,
   type HeatStats,
   type HeatEntry,
@@ -1081,6 +1083,31 @@ async function executeComplete(options: DispatchCompleteOptions): Promise<void> 
   // Remove lock
   await removeLock(agentsDir);
 
+  // Track heat references from action text (Issue #113 — Cognitive Memory)
+  // Non-blocking: heat tracking failures shouldn't break dispatch
+  let heatTrackingInfo: string | null = null;
+  try {
+    const heatStore = createHeatStore(agentsDir);
+    await heatStore.load();
+
+    // Track references from action and reflection
+    const textsToTrack = [options.action];
+    if (options.reflection) {
+      textsToTrack.push(options.reflection);
+    }
+
+    const trackingResult = await trackMultipleReferences(textsToTrack, heatStore);
+
+    // Only show if we tracked something
+    if (trackingResult.created.length > 0 || trackingResult.incremented.length > 0) {
+      heatTrackingInfo = formatTrackingResult(trackingResult);
+    }
+  } catch (err) {
+    // Heat tracking is non-critical — log but don't fail
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(chalk.dim(`[Heat] Reference tracking skipped: ${message}`));
+  }
+
   // Record observability metrics if tokens provided (Issue #83 — Dogfooding)
   if (options.tokensIn !== undefined || options.tokensOut !== undefined) {
     const model = options.model ?? 'claude-4-sonnet';
@@ -1250,13 +1277,18 @@ async function executeComplete(options: DispatchCompleteOptions): Promise<void> 
         recorded: true,
       };
     }
+    // Include heat tracking info if we tracked references
+    if (heatTrackingInfo) {
+      output.heat = { tracked: heatTrackingInfo };
+    }
     console.log(JSON.stringify(output));
     return;
   }
 
   if (options.quiet) {
     const pushStatus = options.skipPush ? 'committed' : (pushed ? 'pushed' : 'push failed');
-    console.log(`Cycle ${newState.cycle_count} complete (${outcome}) — ${pushStatus}`);
+    const heatSuffix = heatTrackingInfo ? ` | 🔥 ${heatTrackingInfo}` : '';
+    console.log(`Cycle ${newState.cycle_count} complete (${outcome}) — ${pushStatus}${heatSuffix}`);
     return;
   }
 
@@ -1292,6 +1324,13 @@ async function executeComplete(options: DispatchCompleteOptions): Promise<void> 
   }
 
   console.log();
+
+  // Show heat tracking info if we tracked any references
+  if (heatTrackingInfo) {
+    console.log(`  ${chalk.gray('Heat:')}      ${chalk.cyan(heatTrackingInfo)}`);
+    console.log();
+  }
+
   if (nextRole) {
     console.log(`  ${chalk.gray('Next:')}      ${formatRole(nextRole)}`);
   }

--- a/packages/core/src/heat/index.ts
+++ b/packages/core/src/heat/index.ts
@@ -71,3 +71,18 @@ export type { EntryType } from './calculate.js';
 export { HeatStore, createHeatStore } from './store.js';
 
 export type { HeatEntry, DecayResult, DecayOptions } from './store.js';
+
+// ─── Reference Tracking (Issue #113 — Cognitive Memory) ─────────────────────
+
+export type {
+  ReferenceType,
+  ParsedReference,
+  TrackingResult,
+} from './reference-tracker.js';
+
+export {
+  extractReferences,
+  trackActionReferences,
+  trackMultipleReferences,
+  formatTrackingResult,
+} from './reference-tracker.js';

--- a/packages/core/src/heat/reference-tracker.ts
+++ b/packages/core/src/heat/reference-tracker.ts
@@ -1,0 +1,264 @@
+/**
+ * @ada/core — Dispatch Heat Reference Tracker
+ *
+ * Tracks memory references from dispatch action text and updates heat scores.
+ * When agents reference lessons (L297), decisions (ADR-001), issues (#118),
+ * or cycles (C776), those entries get their heat scores boosted.
+ *
+ * This closes the feedback loop: frequently-referenced memories stay hot,
+ * rarely-referenced memories decay to cold storage.
+ *
+ * @example
+ * ```typescript
+ * import { trackActionReferences } from '@ada/core/heat';
+ *
+ * const result = await trackActionReferences(
+ *   '🌌 DISPATCH HEAT INTEGRATION (C776) — Per L410, using heat scoring. Relates to #113.',
+ *   heatStore
+ * );
+ * // result.tracked = ['L410', '#113', 'C776']
+ * // result.created = ['L410'] (if new)
+ * // result.incremented = ['#113', 'C776'] (if existed)
+ * ```
+ *
+ * @see docs/design/memory-heat-cli-spec-c629.md §4.2 Reference Tracking
+ * @see Issue #113 — Cognitive Memory Architecture
+ * @packageDocumentation
+ */
+
+import type { HeatStore, HeatEntry } from './store.js';
+import type { MemoryClass } from './types.js';
+
+// ─── Reference Types ────────────────────────────────────────────────────────
+
+/**
+ * Types of references we track from action text.
+ */
+export type ReferenceType = 'lesson' | 'decision' | 'issue' | 'cycle';
+
+/**
+ * A parsed reference from action text.
+ */
+export interface ParsedReference {
+  /** The full reference string (e.g., 'L410', 'ADR-001', '#113', 'C776') */
+  readonly ref: string;
+
+  /** The type of reference */
+  readonly type: ReferenceType;
+
+  /** The numeric ID extracted */
+  readonly id: number;
+}
+
+/**
+ * Result of tracking references in action text.
+ */
+export interface TrackingResult {
+  /** All references found in the text */
+  readonly found: readonly ParsedReference[];
+
+  /** References that were incremented (already existed) */
+  readonly incremented: readonly string[];
+
+  /** References that were created (new entries) */
+  readonly created: readonly string[];
+
+  /** References that failed to track (errors) */
+  readonly errors: readonly string[];
+}
+
+// ─── Reference Patterns ─────────────────────────────────────────────────────
+
+/**
+ * Patterns to detect references in action text.
+ * Order matters for extraction precedence.
+ */
+const REFERENCE_PATTERNS: ReadonlyArray<{
+  readonly type: ReferenceType;
+  readonly pattern: RegExp;
+}> = [
+  // Lessons: L1, L297, L410
+  { type: 'lesson', pattern: /\bL(\d+)\b/g },
+
+  // Architecture Decisions: ADR-001, adr-001
+  { type: 'decision', pattern: /\bADR-(\d+)\b/gi },
+
+  // Issues: #113, #118, #155
+  { type: 'issue', pattern: /\B#(\d+)\b/g },
+
+  // Cycles: C776, C629
+  { type: 'cycle', pattern: /\bC(\d+)\b/g },
+];
+
+// ─── Memory Class Mapping ───────────────────────────────────────────────────
+
+/**
+ * Base importance by reference type.
+ * Higher importance = slower decay.
+ *
+ * @see docs/design/memory-heat-cli-spec-c629.md §2 Memory Heat Types
+ */
+const BASE_IMPORTANCE: Record<ReferenceType, number> = {
+  lesson: 0.8, // Lessons are highly valuable
+  decision: 0.9, // Architecture decisions are critical
+  issue: 0.6, // Issues have moderate importance
+  cycle: 0.5, // Cycles are contextual
+};
+
+/**
+ * Memory class by reference type.
+ */
+const MEMORY_CLASS: Record<ReferenceType, MemoryClass> = {
+  lesson: 'learned', // Lessons are learned from experience
+  decision: 'innate', // Decisions should be stable (near-innate)
+  issue: 'learned', // Issues are operational context
+  cycle: 'learned', // Cycles are ephemeral context
+};
+
+// ─── Extraction ─────────────────────────────────────────────────────────────
+
+/**
+ * Extract all references from action text.
+ *
+ * @param text - Action description or reflection text
+ * @returns Array of parsed references (deduplicated)
+ */
+export function extractReferences(text: string): ParsedReference[] {
+  const seen = new Set<string>();
+  const refs: ParsedReference[] = [];
+
+  for (const { type, pattern } of REFERENCE_PATTERNS) {
+    // Reset regex state for each pattern
+    const regex = new RegExp(pattern.source, pattern.flags);
+
+    for (const match of text.matchAll(regex)) {
+      const ref = match[0].toUpperCase(); // Normalize to uppercase
+      const idStr = match[1];
+
+      // Skip if no capture group (shouldn't happen with our patterns)
+      if (!idStr) continue;
+
+      const id = parseInt(idStr, 10);
+
+      // Deduplicate
+      if (!seen.has(ref)) {
+        seen.add(ref);
+        refs.push({ ref, type, id });
+      }
+    }
+  }
+
+  return refs;
+}
+
+// ─── Tracking ───────────────────────────────────────────────────────────────
+
+/**
+ * Track references from action text and update heat store.
+ *
+ * For each reference found:
+ * - If entry exists: increment reference count
+ * - If entry doesn't exist: create with base importance
+ *
+ * @param text - Action description (from dispatch complete)
+ * @param store - Heat store to update
+ * @param persist - Whether to save after each update (default: false for batch, save once at end)
+ * @returns Tracking result with found, incremented, created, errors
+ */
+export async function trackActionReferences(
+  text: string,
+  store: HeatStore,
+  persist: boolean = true
+): Promise<TrackingResult> {
+  const found = extractReferences(text);
+  const incremented: string[] = [];
+  const created: string[] = [];
+  const errors: string[] = [];
+
+  const now = Date.now();
+
+  for (const { ref, type } of found) {
+    try {
+      const existing = store.get(ref);
+
+      if (existing) {
+        // Increment existing entry
+        await store.increment(ref, false); // Batch: don't persist yet
+        incremented.push(ref);
+      } else {
+        // Create new entry
+        const entry: HeatEntry = {
+          id: ref,
+          memoryClass: MEMORY_CLASS[type],
+          baseImportance: BASE_IMPORTANCE[type],
+          referenceCount: 1, // First reference
+          lastAccessedAt: now,
+          createdAt: now,
+        };
+        await store.set(entry, false); // Batch: don't persist yet
+        created.push(ref);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[ReferenceTracker] Failed to track ${ref}: ${message}`);
+      errors.push(ref);
+    }
+  }
+
+  // Persist once at end (if requested)
+  if (persist && (incremented.length > 0 || created.length > 0)) {
+    await store.save();
+  }
+
+  return {
+    found,
+    incremented,
+    created,
+    errors,
+  };
+}
+
+/**
+ * Track references from multiple text sources (e.g., action + reflection).
+ *
+ * @param texts - Array of text sources to scan
+ * @param store - Heat store to update
+ * @returns Combined tracking result
+ */
+export function trackMultipleReferences(
+  texts: string[],
+  store: HeatStore
+): Promise<TrackingResult> {
+  // Combine all texts
+  const combined = texts.filter(Boolean).join('\n');
+  return trackActionReferences(combined, store);
+}
+
+/**
+ * Get a summary string for the tracking result.
+ * Useful for logging or display.
+ *
+ * @param result - Tracking result
+ * @returns Human-readable summary
+ */
+export function formatTrackingResult(result: TrackingResult): string {
+  const parts: string[] = [];
+
+  if (result.created.length > 0) {
+    parts.push(`created: ${result.created.join(', ')}`);
+  }
+
+  if (result.incremented.length > 0) {
+    parts.push(`boosted: ${result.incremented.join(', ')}`);
+  }
+
+  if (result.errors.length > 0) {
+    parts.push(`errors: ${result.errors.join(', ')}`);
+  }
+
+  if (parts.length === 0) {
+    return 'no references tracked';
+  }
+
+  return parts.join(' | ');
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -403,6 +403,20 @@ export { normalizeImportance as normalizeHeatImportance } from './heat/index.js'
 // Note: HeatTier, HeatSignalType, HeatSignal, getHeatTier exported from terminal for now.
 // Sprint 2 will refactor terminal to import from heat module.
 
+// Heat Reference Tracking (Issue #113 — Cognitive Memory, Dispatch Integration)
+// Tracks memory references from dispatch action text and updates heat scores.
+export type {
+  ReferenceType,
+  ParsedReference,
+  TrackingResult,
+} from './heat/index.js';
+export {
+  extractReferences,
+  trackActionReferences,
+  trackMultipleReferences,
+  formatTrackingResult,
+} from './heat/index.js';
+
 // Heat-Aware Retrieval (Issue #118 — Phase 4 Task 6: Heat + Memory Stream Integration)
 export type {
   HeatRetrievalOptions,

--- a/packages/core/tests/heat/reference-tracker.test.ts
+++ b/packages/core/tests/heat/reference-tracker.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Tests for heat reference tracker.
+ *
+ * @see packages/core/src/heat/reference-tracker.ts
+ * @see docs/design/memory-heat-cli-spec-c629.md §4.2
+ * @see Issue #113 — Cognitive Memory Architecture
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  extractReferences,
+  trackActionReferences,
+  trackMultipleReferences,
+  formatTrackingResult,
+} from '../../src/heat/reference-tracker.js';
+import { HeatStore } from '../../src/heat/store.js';
+
+describe('extractReferences', () => {
+  describe('lesson references (L###)', () => {
+    it('extracts single lesson reference', () => {
+      const refs = extractReferences('Per L410, we should use heat scoring.');
+      expect(refs).toHaveLength(1);
+      expect(refs[0]).toEqual({ ref: 'L410', type: 'lesson', id: 410 });
+    });
+
+    it('extracts multiple lesson references', () => {
+      const refs = extractReferences('Based on L297 and L410, the pattern is clear.');
+      expect(refs).toHaveLength(2);
+      expect(refs.map((r) => r.ref)).toEqual(['L297', 'L410']);
+    });
+
+    it('handles lowercase lesson references', () => {
+      const refs = extractReferences('per l410');
+      // Lowercase 'l' doesn't match \bL(\d+)\b pattern (case sensitive)
+      expect(refs).toHaveLength(0);
+    });
+
+    it('ignores lesson-like text in words', () => {
+      // 'LOGICAL' contains 'L' but no number follows
+      const refs = extractReferences('LOGICAL thinking required');
+      expect(refs).toHaveLength(0);
+    });
+  });
+
+  describe('decision references (ADR-###)', () => {
+    it('extracts single ADR reference', () => {
+      const refs = extractReferences('Per ADR-001, types flow downstream.');
+      expect(refs).toHaveLength(1);
+      expect(refs[0]).toEqual({ ref: 'ADR-001', type: 'decision', id: 1 });
+    });
+
+    it('handles lowercase ADR', () => {
+      const refs = extractReferences('per adr-001');
+      expect(refs).toHaveLength(1);
+      expect(refs[0].ref).toBe('ADR-001'); // Normalized to uppercase
+    });
+
+    it('extracts multiple ADR references', () => {
+      const refs = extractReferences('ADR-001 supersedes ADR-002');
+      expect(refs).toHaveLength(2);
+    });
+  });
+
+  describe('issue references (####)', () => {
+    it('extracts single issue reference', () => {
+      const refs = extractReferences('Relates to #113');
+      expect(refs).toHaveLength(1);
+      expect(refs[0]).toEqual({ ref: '#113', type: 'issue', id: 113 });
+    });
+
+    it('extracts multiple issue references', () => {
+      const refs = extractReferences('Closes #113, relates to #118');
+      expect(refs).toHaveLength(2);
+      expect(refs.map((r) => r.ref)).toEqual(['#113', '#118']);
+    });
+
+    it('handles issue references in parens', () => {
+      const refs = extractReferences('(#155)');
+      expect(refs).toHaveLength(1);
+      expect(refs[0].ref).toBe('#155');
+    });
+  });
+
+  describe('cycle references (C###)', () => {
+    it('extracts single cycle reference', () => {
+      const refs = extractReferences('As noted in C776');
+      expect(refs).toHaveLength(1);
+      expect(refs[0]).toEqual({ ref: 'C776', type: 'cycle', id: 776 });
+    });
+
+    it('extracts multiple cycle references', () => {
+      const refs = extractReferences('C766 through C776 show progress');
+      expect(refs).toHaveLength(2);
+    });
+
+    it('handles cycle in parentheses', () => {
+      const refs = extractReferences('(C776)');
+      expect(refs).toHaveLength(1);
+    });
+  });
+
+  describe('mixed references', () => {
+    it('extracts all reference types from action text', () => {
+      const action =
+        '🌌 DISPATCH HEAT INTEGRATION (C776) — Per L410 and ADR-001, implementing reference tracking. Relates to #113.';
+      const refs = extractReferences(action);
+
+      expect(refs).toHaveLength(4);
+      expect(refs.map((r) => r.ref).sort()).toEqual(['#113', 'ADR-001', 'C776', 'L410']);
+    });
+
+    it('deduplicates repeated references', () => {
+      const refs = extractReferences('L410 is important. As L410 shows...');
+      expect(refs).toHaveLength(1);
+    });
+
+    it('handles empty string', () => {
+      const refs = extractReferences('');
+      expect(refs).toHaveLength(0);
+    });
+
+    it('handles text with no references', () => {
+      const refs = extractReferences('Just some regular text without any references.');
+      expect(refs).toHaveLength(0);
+    });
+  });
+});
+
+describe('trackActionReferences', () => {
+  let tempDir: string;
+  let heatPath: string;
+  let store: HeatStore;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ada-heat-test-'));
+    heatPath = path.join(tempDir, 'heat.jsonl');
+    store = new HeatStore(heatPath);
+    await store.load();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true });
+  });
+
+  it('creates new entries for first-time references', async () => {
+    const result = await trackActionReferences('Per L410 and #113', store);
+
+    expect(result.found).toHaveLength(2);
+    expect(result.created).toContain('L410');
+    expect(result.created).toContain('#113');
+    expect(result.incremented).toHaveLength(0);
+
+    // Verify entries exist
+    const l410 = store.get('L410');
+    expect(l410).not.toBeNull();
+    expect(l410?.baseImportance).toBe(0.8); // lesson importance
+    expect(l410?.memoryClass).toBe('learned');
+    expect(l410?.referenceCount).toBe(1);
+
+    const issue = store.get('#113');
+    expect(issue).not.toBeNull();
+    expect(issue?.baseImportance).toBe(0.6); // issue importance
+  });
+
+  it('increments existing entries on subsequent references', async () => {
+    // First reference
+    await trackActionReferences('L410 mentioned', store);
+
+    // Second reference
+    const result = await trackActionReferences('Per L410 again', store);
+
+    expect(result.incremented).toContain('L410');
+    expect(result.created).toHaveLength(0);
+
+    const entry = store.get('L410');
+    expect(entry?.referenceCount).toBe(2);
+  });
+
+  it('handles mixed new and existing references', async () => {
+    // Create L410 first
+    await trackActionReferences('L410', store);
+
+    // Now reference L410 and new #113
+    const result = await trackActionReferences('Per L410 and #113', store);
+
+    expect(result.incremented).toContain('L410');
+    expect(result.created).toContain('#113');
+  });
+
+  it('persists entries to file', async () => {
+    await trackActionReferences('L410', store);
+
+    // Create new store and load
+    const newStore = new HeatStore(heatPath);
+    await newStore.load();
+
+    const entry = newStore.get('L410');
+    expect(entry).not.toBeNull();
+    expect(entry?.referenceCount).toBe(1);
+  });
+
+  it('assigns correct memory class by type', async () => {
+    await trackActionReferences('L410 ADR-001 #113 C776', store);
+
+    expect(store.get('L410')?.memoryClass).toBe('learned');
+    expect(store.get('ADR-001')?.memoryClass).toBe('innate');
+    expect(store.get('#113')?.memoryClass).toBe('learned');
+    expect(store.get('C776')?.memoryClass).toBe('learned');
+  });
+
+  it('assigns correct base importance by type', async () => {
+    await trackActionReferences('L410 ADR-001 #113 C776', store);
+
+    expect(store.get('L410')?.baseImportance).toBe(0.8); // lesson
+    expect(store.get('ADR-001')?.baseImportance).toBe(0.9); // decision
+    expect(store.get('#113')?.baseImportance).toBe(0.6); // issue
+    expect(store.get('C776')?.baseImportance).toBe(0.5); // cycle
+  });
+
+  it('returns empty result for text without references', async () => {
+    const result = await trackActionReferences('No references here', store);
+
+    expect(result.found).toHaveLength(0);
+    expect(result.created).toHaveLength(0);
+    expect(result.incremented).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+});
+
+describe('trackMultipleReferences', () => {
+  let tempDir: string;
+  let store: HeatStore;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ada-heat-test-'));
+    store = new HeatStore(path.join(tempDir, 'heat.jsonl'));
+    await store.load();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true });
+  });
+
+  it('tracks references from multiple text sources', async () => {
+    const texts = ['Action: L410 referenced', 'Reflection: Also C776'];
+
+    const result = await trackMultipleReferences(texts, store);
+
+    expect(result.found).toHaveLength(2);
+    expect(result.created).toContain('L410');
+    expect(result.created).toContain('C776');
+  });
+
+  it('handles empty array', async () => {
+    const result = await trackMultipleReferences([], store);
+    expect(result.found).toHaveLength(0);
+  });
+
+  it('filters out empty strings', async () => {
+    const texts = ['L410', '', 'C776', ''];
+    const result = await trackMultipleReferences(texts, store);
+
+    expect(result.created).toHaveLength(2);
+  });
+
+  it('deduplicates across texts', async () => {
+    const texts = ['L410 mentioned', 'L410 again'];
+    const result = await trackMultipleReferences(texts, store);
+
+    // L410 appears in both but should only be created once
+    expect(result.created).toEqual(['L410']);
+    expect(store.get('L410')?.referenceCount).toBe(1);
+  });
+});
+
+describe('formatTrackingResult', () => {
+  it('formats created entries', () => {
+    const result = {
+      found: [],
+      created: ['L410', '#113'],
+      incremented: [],
+      errors: [],
+    };
+
+    expect(formatTrackingResult(result)).toBe('created: L410, #113');
+  });
+
+  it('formats incremented entries', () => {
+    const result = {
+      found: [],
+      created: [],
+      incremented: ['L410', '#113'],
+      errors: [],
+    };
+
+    expect(formatTrackingResult(result)).toBe('boosted: L410, #113');
+  });
+
+  it('formats mixed results', () => {
+    const result = {
+      found: [],
+      created: ['L410'],
+      incremented: ['#113'],
+      errors: [],
+    };
+
+    expect(formatTrackingResult(result)).toBe('created: L410 | boosted: #113');
+  });
+
+  it('formats errors', () => {
+    const result = {
+      found: [],
+      created: [],
+      incremented: [],
+      errors: ['BAD-REF'],
+    };
+
+    expect(formatTrackingResult(result)).toBe('errors: BAD-REF');
+  });
+
+  it('returns "no references tracked" for empty result', () => {
+    const result = {
+      found: [],
+      created: [],
+      incremented: [],
+      errors: [],
+    };
+
+    expect(formatTrackingResult(result)).toBe('no references tracked');
+  });
+});


### PR DESCRIPTION
## Summary

Implements reference tracking from dispatch action text per C629 spec (#113 — Cognitive Memory).

When agents reference lessons (L###), decisions (ADR-###), issues (####), or cycles (C###) in their action text, those entries get heat-boosted in the heat store.

## Changes Made

### Core (`packages/core`)
- **`src/heat/reference-tracker.ts`** (new, 7.4KB)
  - `extractReferences()`: Parse all reference types from text
  - `trackActionReferences()`: Track refs and update heat store
  - `trackMultipleReferences()`: Batch tracking from action + reflection
  - `formatTrackingResult()`: Human-readable tracking summary
- **`src/heat/index.ts`**: Export new reference tracker
- **`src/index.ts`**: Export new types and functions

### CLI (`packages/cli`)
- **`src/commands/dispatch.ts`**: Integrate heat tracking into `ada dispatch complete`
  - Tracks references from action text and reflection
  - Shows heat info in output: `Heat: created: L410 | boosted: #113`
  - Non-blocking: heat tracking failures don't break dispatch

### Tests
- **`tests/heat/reference-tracker.test.ts`** (new, 33 tests)
  - Extraction tests for all reference types
  - Tracking tests (create, increment, persist)
  - Memory class and importance assignment
  - Formatting tests

## Type of Change
- `feat` — New feature (reference tracking)

## Related Issues
- Relates to #113 (Cognitive Memory Architecture)
- Implements spec from `docs/design/memory-heat-cli-spec-c629.md` §4.2

## Testing
- [x] All 33 new tests pass
- [x] All 151 heat module tests pass
- [x] Build succeeds (TypeScript strict mode)
- [x] Lint passes

## Checklist
- [x] PR title follows conventional commit format
- [x] Tests included
- [x] Documentation in code comments

---
*🌌 The Frontier — Cycle 776*