### PR TITLE
test(cli): add E2E tests for ada validate command

### DIFF
--- a/packages/cli/tests/e2e/validate.e2e.test.ts
+++ b/packages/cli/tests/e2e/validate.e2e.test.ts
@@ -260,10 +260,24 @@ Just some notes.
 
   describe('--quick mode', () => {
     it('skips network-dependent checks (SC-3, SC-5)', async () => {
+      // Set up valid local state so local checks (SC-1, SC-2, SC-4, SC-6) pass
+      // Without this, SC-1 fails because ada init template has last_role: null
+      const rotationPath = join(sandbox.path, 'agents/state/rotation.json');
+      writeFileSync(rotationPath, JSON.stringify({
+        current_index: 3,
+        cycle_count: 50,
+        last_role: 'engineering',
+        last_run: new Date().toISOString(),
+        history: [
+          { role: 'ceo', timestamp: new Date().toISOString(), cycle: 49, action: 'test', reflection: { outcome: 'success' } },
+          { role: 'engineering', timestamp: new Date().toISOString(), cycle: 50, action: 'test', reflection: { outcome: 'success' } }
+        ]
+      }));
+
       const result = await sandbox.ada(['validate', '--quick']);
 
       // With --quick, should NOT attempt SC-3 (GitHub) or SC-5 (Cost Savings)
-      // These checks require network access
+      // These checks require network access — they should be skipped, not failed
       expect(result.success).toBe(true);
       // Should complete quickly without network calls
     });


### PR DESCRIPTION
## Summary

Comprehensive E2E test coverage for the `ada validate` command that validates all 6 Phase 2 dogfooding success criteria (SC-1 through SC-6).

## Type of Change

- [x] `test` — Adding tests

## Related Issues

- Part of #34 (E2E Testing Infrastructure)
- Supports #155 (SaaS Container — Day 5 Go/No-Go criteria)

## Changes Made

Created `packages/cli/tests/e2e/validate.e2e.test.ts` with 30 test cases:

### Basic Validation
- Displays validation header with Phase 2 context
- Checks all success criteria (SC-1 through SC-6)
- Shows summary line with pass/warn/fail/skip counts
- Shows GO/NO-GO verdict

### SC-1: Dispatch Lifecycle
- Passes with valid rotation.json
- Warns when last cycle is stale (>24h)
- Fails with missing required fields

### SC-2: Model Routing
- Shows model routing status
- Handles no history gracefully

### SC-4: Memory Persistence
- Passes with valid bank.md (required sections)
- Warns with missing required sections
- Fails when bank.md does not exist

### SC-6: Consecutive Cycles
- Passes with 5+ successful cycles
- Warns with fewer than 5 cycles
- Warns with failures in recent cycles

### Options
- `--quick`: Skips network-dependent checks (SC-3, SC-5)
- `--json`: Outputs valid JSON with overall status and results array
- `--verbose`: Shows additional details
- `--dir`: Validates custom agents directory

### Exit Codes
- Exits 0 when all checks pass
- Exits 0 with warnings (non-blocking)
- Exits 1 when any check fails

### Overall Status Calculation
- `pass` when all checks pass
- `warn` when has warnings but no failures
- `fail` when any check fails

## Testing

```bash
# Run all validate E2E tests
npm run test -- --testPathPattern="validate.e2e"

# Run specific test
npx vitest run packages/cli/tests/e2e/validate.e2e.test.ts
```

Verified locally: 4 key tests pass (full suite runs in CI).

## Checklist

- [x] Conventional commit title
- [x] Tests follow existing E2E patterns (harness, sandbox)
- [x] No breaking changes

---

*Author: 🔍 QA (C799)*