### PR TITLE
feat(waitlist): add Vercel deployment configuration

### DIFF
--- a/apps/waitlist/.env.example
+++ b/apps/waitlist/.env.example
@@ -1,0 +1,13 @@
+# Supabase Configuration
+# Get these from: https://supabase.com/dashboard/project/<project-id>/settings/api
+
+# Supabase Project URL
+VITE_SUPABASE_URL=https://ldzxplhmtxfhiunpzmnt.supabase.co
+
+# Supabase Anon/Public Key (safe to expose in frontend)
+VITE_SUPABASE_PUBLISHABLE_KEY=your-anon-key-here
+
+# Notes:
+# - These variables are prefixed with VITE_ so Vite exposes them to the client
+# - The publishable key is safe to commit; the service role key should NEVER be committed
+# - For Vercel deployment, add these in Project Settings → Environment Variables

--- a/apps/waitlist/README.md
+++ b/apps/waitlist/README.md
@@ -1,73 +1,116 @@
-# Welcome to your Lovable project
+# ADA Waitlist Website
 
-## Project info
+Temporary waitlist landing page for ADA SaaS launch. Collects email signups while the full marketing site is in development.
 
-**URL**: https://lovable.dev/projects/REPLACE_WITH_PROJECT_ID
+## Tech Stack
 
-## How can I edit this code?
+- **Framework:** React 18 + Vite
+- **Styling:** Tailwind CSS + shadcn/ui
+- **Database:** Supabase (PostgreSQL)
+- **Deployment:** Vercel
 
-There are several ways of editing your application.
+## Features
 
-**Use Lovable**
+- 🎨 Modern, responsive landing page
+- 📧 Email waitlist signup with Supabase
+- 📊 Real-time waitlist count display
+- 🔒 Duplicate email prevention
+- ⚡ Optimized build with code splitting
 
-Simply visit the [Lovable Project](https://lovable.dev/projects/REPLACE_WITH_PROJECT_ID) and start prompting.
+## Local Development
 
-Changes made via Lovable will be committed automatically to this repo.
+```bash
+# Install dependencies
+npm install
 
-**Use your preferred IDE**
+# Copy environment variables
+cp .env.example .env
 
-If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
+# Fill in your Supabase credentials in .env
+# Get them from: https://supabase.com/dashboard/project/<project-id>/settings/api
 
-The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
-
-Follow these steps:
-
-```sh
-# Step 1: Clone the repository using the project's Git URL.
-git clone <YOUR_GIT_URL>
-
-# Step 2: Navigate to the project directory.
-cd <YOUR_PROJECT_NAME>
-
-# Step 3: Install the necessary dependencies.
-npm i
-
-# Step 4: Start the development server with auto-reloading and an instant preview.
+# Start dev server
 npm run dev
 ```
 
-**Edit a file directly in GitHub**
+## Environment Variables
 
-- Navigate to the desired file(s).
-- Click the "Edit" button (pencil icon) at the top right of the file view.
-- Make your changes and commit the changes.
+| Variable                        | Description              | Required |
+| ------------------------------- | ------------------------ | -------- |
+| `VITE_SUPABASE_URL`             | Supabase project URL     | ✅       |
+| `VITE_SUPABASE_PUBLISHABLE_KEY` | Supabase anon/public key | ✅       |
 
-**Use GitHub Codespaces**
+## Deployment (Vercel)
 
-- Navigate to the main page of your repository.
-- Click on the "Code" button (green button) near the top right.
-- Select the "Codespaces" tab.
-- Click on "New codespace" to launch a new Codespace environment.
-- Edit files directly within the Codespace and commit and push your changes once you're done.
+### Quick Deploy
 
-## What technologies are used for this project?
+1. **Connect Repository**
+   - Go to [Vercel Dashboard](https://vercel.com/new)
+   - Import the `autonomous-dev-agents` repo
+   - Set Root Directory to `apps/waitlist`
 
-This project is built with:
+2. **Configure Environment Variables**
+   - Add `VITE_SUPABASE_URL` and `VITE_SUPABASE_PUBLISHABLE_KEY`
+   - Get values from [Supabase Dashboard](https://supabase.com/dashboard)
 
-- Vite
-- TypeScript
-- React
-- shadcn-ui
-- Tailwind CSS
+3. **Deploy**
+   - Vercel will auto-detect Vite and deploy
 
-## How can I deploy this project?
+### Custom Domain (Optional)
 
-Simply open [Lovable](https://lovable.dev/projects/REPLACE_WITH_PROJECT_ID) and click on Share -> Publish.
+1. Go to Project Settings → Domains
+2. Add your domain (e.g., `waitlist.ada.dev`)
+3. Configure DNS as instructed
 
-## Can I connect a custom domain to my Lovable project?
+## Supabase Setup
 
-Yes, you can!
+The waitlist uses these Supabase resources:
 
-To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
+### Table: `waitlist`
 
-Read more here: [Setting up a custom domain](https://docs.lovable.dev/features/custom-domain#custom-domain)
+```sql
+CREATE TABLE waitlist (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Enable RLS
+ALTER TABLE waitlist ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Allow anonymous inserts
+CREATE POLICY "Allow anonymous inserts" ON waitlist
+  FOR INSERT TO anon
+  WITH CHECK (true);
+```
+
+### Function: `get_waitlist_count`
+
+```sql
+CREATE OR REPLACE FUNCTION get_waitlist_count()
+RETURNS INTEGER AS $$
+  SELECT COUNT(*)::INTEGER FROM waitlist;
+$$ LANGUAGE SQL SECURITY DEFINER;
+```
+
+## Scripts
+
+| Script              | Description              |
+| ------------------- | ------------------------ |
+| `npm run dev`       | Start development server |
+| `npm run build`     | Build for production     |
+| `npm run preview`   | Preview production build |
+| `npm run lint`      | Run ESLint               |
+| `npm run typecheck` | Run TypeScript checks    |
+
+## Lifecycle
+
+1. **Now:** Active — collecting signups
+2. **Later:** Deprecate when `apps/web/` is production-ready
+3. **Eventually:** Archive or remove, migrate signups
+
+## Related
+
+- Issue: [#200](https://github.com/ishan190425/autonomous-dev-agents/issues/200)
+- Full Marketing Site: `apps/web/` (planned)
+- Supabase Project: `ldzxplhmtxfhiunpzmnt`

--- a/apps/waitlist/vercel.json
+++ b/apps/waitlist/vercel.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "installCommand": "npm install",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds deployment configuration to make the waitlist app ready for Vercel deployment.

## Changes

- **vercel.json** — Vite framework config, SPA rewrites, security headers, caching
- **.env.example** — Documents required Supabase environment variables
- **README.md** — Comprehensive deployment guide, Supabase setup SQL, local dev instructions

## Deployment Steps (for human)

1. Go to [Vercel Dashboard](https://vercel.com/new)
2. Import repo, set Root Directory to `apps/waitlist`
3. Add env vars:
   - `VITE_SUPABASE_URL`: `https://ldzxplhmtxfhiunpzmnt.supabase.co`
   - `VITE_SUPABASE_PUBLISHABLE_KEY`: (get from Supabase dashboard)
4. Deploy

## Related

- Closes partial for #200 (deployment pipeline requirement)
- Part of P0-parallel waitlist track (CEO directive C883)

## Testing

- [x] TypeScript compiles (`npm run typecheck`)
- [x] vercel.json schema valid
- [ ] Vercel deployment (requires human action)

---
**Cycle:** 890 | **Role:** ⚙️ Engineering | **Consecutive:** 469