### PR TITLE
feat(core): add structured logger with JSON/text/pretty output

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -198,6 +198,26 @@ export {
   calculateSavingsAnalysis,
 } from './observability.js';
 
+// Telemetry — Structured Logging (Phase 1, C896)
+export type {
+  LogLevel,
+  LogContext,
+  LogEntry,
+  Logger,
+  LogFormat,
+  LogOutput,
+  LoggerConfig,
+} from './telemetry/index.js';
+export {
+  LOG_LEVEL_VALUES,
+  createLogger,
+  createSilentLogger,
+  createLoggerFromEnv,
+  getLogger,
+  setLogger,
+  resetLogger,
+} from './telemetry/index.js';
+
 // Memory Importance Tracking (Phase 3.1)
 export type {
   MemoryImportance,

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @ada/core — Telemetry Module
+ *
+ * Structured logging, tracing, and unified observability.
+ * Phase 1: Structured Logging (C896)
+ * Phase 2: Distributed Tracing (planned)
+ *
+ * Part of SaaS Observability & Telemetry Specification (C886).
+ *
+ * @packageDocumentation
+ */
+
+export * from './logger.js';
+export * from './types.js';

--- a/packages/core/src/telemetry/logger.ts
+++ b/packages/core/src/telemetry/logger.ts
@@ -1,0 +1,402 @@
+/**
+ * @ada/core — Structured Logger Implementation
+ *
+ * JSON Lines and human-readable logging with context propagation.
+ * Part of SaaS Observability & Telemetry Specification (C886).
+ *
+ * @packageDocumentation
+ */
+
+import * as fs from 'node:fs';
+import type {
+  Logger,
+  LoggerConfig,
+  LogContext,
+  LogEntry,
+  LogFormat,
+  LogLevel,
+  LogOutput,
+} from './types.js';
+import { LOG_LEVEL_VALUES } from './types.js';
+
+// ─── Formatters ──────────────────────────────────────────────────────────────
+
+/**
+ * Format a log entry as JSON Lines (one JSON object per line).
+ */
+function formatJson(entry: LogEntry): string {
+  return JSON.stringify(entry);
+}
+
+/**
+ * Format a log entry as human-readable text.
+ */
+function formatText(entry: LogEntry, includeTimestamp: boolean): string {
+  const parts: string[] = [];
+
+  // Timestamp
+  if (includeTimestamp) {
+    const time = new Date(entry.timestamp).toLocaleTimeString('en-US', {
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+    parts.push(`[${time}]`);
+  }
+
+  // Level
+  const levelStr = entry.level.toUpperCase().padEnd(5);
+  parts.push(levelStr);
+
+  // Context (compact)
+  const contextParts: string[] = [];
+  if (entry.context.cycleId !== undefined) {
+    contextParts.push(`C${entry.context.cycleId}`);
+  }
+  if (entry.context.role) {
+    contextParts.push(entry.context.role);
+  }
+  if (contextParts.length > 0) {
+    parts.push(`[${contextParts.join('/')}]`);
+  }
+
+  // Message
+  parts.push(entry.message);
+
+  // Metadata (inline key=value)
+  if (entry.metadata && Object.keys(entry.metadata).length > 0) {
+    const metaStr = Object.entries(entry.metadata)
+      .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+      .join(' ');
+    parts.push(`(${metaStr})`);
+  }
+
+  // Error
+  if (entry.error) {
+    parts.push(`— ${entry.error.name}: ${entry.error.message}`);
+    if (entry.error.stack) {
+      return `${parts.join(' ')  }\n${  entry.error.stack}`;
+    }
+  }
+
+  return parts.join(' ');
+}
+
+/**
+ * Format a log entry with ANSI colors (for TTY).
+ */
+function formatPretty(entry: LogEntry, includeTimestamp: boolean): string {
+  const colors: Record<LogLevel, string> = {
+    trace: '\x1b[90m', // gray
+    debug: '\x1b[36m', // cyan
+    info: '\x1b[32m', // green
+    warn: '\x1b[33m', // yellow
+    error: '\x1b[31m', // red
+  };
+  const reset = '\x1b[0m';
+  const dim = '\x1b[2m';
+
+  const parts: string[] = [];
+
+  // Timestamp (dimmed)
+  if (includeTimestamp) {
+    const time = new Date(entry.timestamp).toLocaleTimeString('en-US', {
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+    parts.push(`${dim}[${time}]${reset}`);
+  }
+
+  // Level (colored)
+  const levelColor = colors[entry.level];
+  const levelStr = entry.level.toUpperCase().padEnd(5);
+  parts.push(`${levelColor}${levelStr}${reset}`);
+
+  // Context (dimmed)
+  const contextParts: string[] = [];
+  if (entry.context.cycleId !== undefined) {
+    contextParts.push(`C${entry.context.cycleId}`);
+  }
+  if (entry.context.role) {
+    contextParts.push(entry.context.role);
+  }
+  if (contextParts.length > 0) {
+    parts.push(`${dim}[${contextParts.join('/')}]${reset}`);
+  }
+
+  // Message
+  parts.push(entry.message);
+
+  // Metadata (dimmed)
+  if (entry.metadata && Object.keys(entry.metadata).length > 0) {
+    const metaStr = Object.entries(entry.metadata)
+      .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+      .join(' ');
+    parts.push(`${dim}(${metaStr})${reset}`);
+  }
+
+  // Error (red)
+  if (entry.error) {
+    parts.push(`${colors.error}— ${entry.error.name}: ${entry.error.message}${reset}`);
+    if (entry.error.stack) {
+      return `${parts.join(' ')  }\n${  dim  }${entry.error.stack  }${reset}`;
+    }
+  }
+
+  return parts.join(' ');
+}
+
+// ─── Output Writers ──────────────────────────────────────────────────────────
+
+type Writer = (line: string) => void;
+
+function createWriter(output: LogOutput, filePath?: string): Writer {
+  switch (output) {
+    case 'stdout':
+      return (line: string) => process.stdout.write(`${line  }\n`);
+    case 'stderr':
+      return (line: string) => process.stderr.write(`${line  }\n`);
+    case 'file': {
+      if (!filePath) {
+        throw new Error('filePath required when output is "file"');
+      }
+      const stream = fs.createWriteStream(filePath, { flags: 'a' });
+      return (line: string) => stream.write(`${line  }\n`);
+    }
+    case 'silent':
+      return () => {}; // No-op
+    default:
+      return (line: string) => process.stderr.write(`${line  }\n`);
+  }
+}
+
+// ─── Logger Implementation ───────────────────────────────────────────────────
+
+/**
+ * Create a logger entry object.
+ */
+function createEntry(
+  level: LogLevel,
+  message: string,
+  context: LogContext,
+  metadata?: Record<string, unknown>,
+  error?: Error
+): LogEntry {
+  const entry: LogEntry = {
+    timestamp: new Date().toISOString(),
+    level,
+    message,
+    context,
+  };
+
+  if (metadata && Object.keys(metadata).length > 0) {
+    (entry as { metadata: Record<string, unknown> }).metadata = metadata;
+  }
+
+  if (error) {
+    const errorEntry: { name: string; message: string; stack?: string } = {
+      name: error.name,
+      message: error.message,
+    };
+    if (error.stack !== undefined) {
+      errorEntry.stack = error.stack;
+    }
+    (entry as { error: typeof errorEntry }).error = errorEntry;
+  }
+
+  return entry;
+}
+
+/**
+ * Internal logger implementation.
+ */
+class LoggerImpl implements Logger {
+  private readonly level: LogLevel;
+  private readonly levelValue: number;
+  private readonly format: LogFormat;
+  private readonly context: LogContext;
+  private readonly write: Writer;
+  private readonly includeTimestamps: boolean;
+  private readonly includeStackTraces: boolean;
+
+  constructor(config: LoggerConfig, writer?: Writer) {
+    this.level = config.level ?? 'info';
+    this.levelValue = LOG_LEVEL_VALUES[this.level];
+    this.format = config.format ?? 'text';
+    this.context = config.context ?? {};
+    this.write = writer ?? createWriter(config.output ?? 'stderr', config.filePath);
+    this.includeTimestamps = config.timestamps ?? true;
+    this.includeStackTraces =
+      config.stackTraces ?? (this.level === 'debug' || this.level === 'trace');
+  }
+
+  private log(
+    level: LogLevel,
+    message: string,
+    metadata?: Record<string, unknown>,
+    error?: Error
+  ): void {
+    // Check if level is enabled
+    if (LOG_LEVEL_VALUES[level] < this.levelValue) {
+      return;
+    }
+
+    // Create entry
+    const entry = createEntry(level, message, this.context, metadata, error);
+
+    // Remove stack trace if not included
+    if (!this.includeStackTraces && entry.error?.stack) {
+      (entry as { error: { name: string; message: string } }).error = {
+        name: entry.error.name,
+        message: entry.error.message,
+      };
+    }
+
+    // Format and write
+    let output: string;
+    switch (this.format) {
+      case 'json':
+        output = formatJson(entry);
+        break;
+      case 'pretty':
+        output = formatPretty(entry, this.includeTimestamps);
+        break;
+      case 'text':
+      default:
+        output = formatText(entry, this.includeTimestamps);
+        break;
+    }
+
+    this.write(output);
+  }
+
+  trace(message: string, metadata?: Record<string, unknown>): void {
+    this.log('trace', message, metadata);
+  }
+
+  debug(message: string, metadata?: Record<string, unknown>): void {
+    this.log('debug', message, metadata);
+  }
+
+  info(message: string, metadata?: Record<string, unknown>): void {
+    this.log('info', message, metadata);
+  }
+
+  warn(message: string, metadata?: Record<string, unknown>): void {
+    this.log('warn', message, metadata);
+  }
+
+  error(message: string, error?: Error, metadata?: Record<string, unknown>): void {
+    this.log('error', message, metadata, error);
+  }
+
+  child(additionalContext: LogContext): Logger {
+    return new LoggerImpl(
+      {
+        level: this.level,
+        format: this.format,
+        timestamps: this.includeTimestamps,
+        stackTraces: this.includeStackTraces,
+        context: { ...this.context, ...additionalContext },
+      },
+      this.write
+    );
+  }
+
+  getContext(): LogContext {
+    return { ...this.context };
+  }
+
+  getLevel(): LogLevel {
+    return this.level;
+  }
+
+  isLevelEnabled(level: LogLevel): boolean {
+    return LOG_LEVEL_VALUES[level] >= this.levelValue;
+  }
+}
+
+// ─── Factory Functions ───────────────────────────────────────────────────────
+
+/**
+ * Create a structured logger.
+ *
+ * @param config - Logger configuration
+ * @returns Logger instance
+ *
+ * @example
+ * ```typescript
+ * // JSON output for machine parsing
+ * const logger = createLogger({ format: 'json', level: 'debug' });
+ *
+ * // Human-readable with context
+ * const cycleLogger = createLogger({
+ *   format: 'pretty',
+ *   context: { cycleId: 896, role: 'frontier' }
+ * });
+ * ```
+ */
+export function createLogger(config: LoggerConfig = {}): Logger {
+  return new LoggerImpl(config);
+}
+
+/**
+ * Create a silent logger (no output).
+ * Useful for testing or when logging is disabled.
+ */
+export function createSilentLogger(): Logger {
+  return createLogger({ output: 'silent' });
+}
+
+/**
+ * Create a logger from environment variables.
+ *
+ * Environment variables:
+ * - ADA_LOG_LEVEL: trace, debug, info, warn, error
+ * - ADA_LOG_FORMAT: json, text, pretty
+ *
+ * @param defaultConfig - Defaults if env vars not set
+ */
+export function createLoggerFromEnv(defaultConfig: LoggerConfig = {}): Logger {
+  const level = (process.env.ADA_LOG_LEVEL as LogLevel) ?? defaultConfig.level;
+  const format = (process.env.ADA_LOG_FORMAT as LogFormat) ?? defaultConfig.format;
+
+  return createLogger({
+    ...defaultConfig,
+    level,
+    format,
+  });
+}
+
+// ─── Global Logger ───────────────────────────────────────────────────────────
+
+let globalLogger: Logger | null = null;
+
+/**
+ * Get or create the global logger instance.
+ * Uses environment variables for configuration.
+ */
+export function getLogger(): Logger {
+  if (!globalLogger) {
+    globalLogger = createLoggerFromEnv({ level: 'info', format: 'text' });
+  }
+  return globalLogger;
+}
+
+/**
+ * Set the global logger instance.
+ * Useful for initializing with specific configuration at startup.
+ */
+export function setLogger(logger: Logger): void {
+  globalLogger = logger;
+}
+
+/**
+ * Reset the global logger (mainly for testing).
+ */
+export function resetLogger(): void {
+  globalLogger = null;
+}

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -1,0 +1,188 @@
+/**
+ * @ada/core — Telemetry Types
+ *
+ * Type definitions for structured logging and observability.
+ *
+ * @packageDocumentation
+ */
+
+// ─── Log Levels ──────────────────────────────────────────────────────────────
+
+/**
+ * Log levels in order of severity.
+ * trace < debug < info < warn < error
+ */
+export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';
+
+/**
+ * Numeric log level values for comparison.
+ */
+export const LOG_LEVEL_VALUES: Record<LogLevel, number> = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+};
+
+// ─── Context ─────────────────────────────────────────────────────────────────
+
+/**
+ * Context that propagates through all log entries.
+ * Enables filtering and correlation of related log entries.
+ */
+export interface LogContext {
+  /** Current dispatch cycle number */
+  readonly cycleId?: number;
+  /** Active agent role */
+  readonly role?: string;
+  /** Unique session identifier */
+  readonly sessionId?: string;
+  /** Distributed trace identifier (for tracing integration) */
+  readonly traceId?: string;
+  /** Span identifier within a trace */
+  readonly spanId?: string;
+  /** Repository path or name */
+  readonly repo?: string;
+  /** Any additional context fields */
+  readonly [key: string]: string | number | boolean | undefined;
+}
+
+// ─── Log Entry ───────────────────────────────────────────────────────────────
+
+/**
+ * A structured log entry.
+ * Designed for JSON serialization and log aggregation systems.
+ */
+export interface LogEntry {
+  /** ISO 8601 timestamp */
+  readonly timestamp: string;
+  /** Log level */
+  readonly level: LogLevel;
+  /** Human-readable message */
+  readonly message: string;
+  /** Propagated context */
+  readonly context: LogContext;
+  /** Additional metadata */
+  readonly metadata?: Record<string, unknown>;
+  /** Error details if present */
+  readonly error?: {
+    readonly name: string;
+    readonly message: string;
+    readonly stack?: string;
+  };
+}
+
+// ─── Logger Interface ────────────────────────────────────────────────────────
+
+/**
+ * Structured logger with context propagation.
+ *
+ * Supports multiple output formats (JSON, human-readable) and
+ * integrates with distributed tracing.
+ *
+ * @example
+ * ```typescript
+ * const logger = createLogger({ format: 'json', level: 'info' });
+ *
+ * // Create a child logger with context
+ * const cycleLogger = logger.child({ cycleId: 896, role: 'frontier' });
+ *
+ * // Log with additional metadata
+ * cycleLogger.info('Cycle started', { memoryVersion: 45 });
+ *
+ * // Error logging with error object
+ * cycleLogger.error('Dispatch failed', new Error('Git push failed'), { retries: 3 });
+ * ```
+ */
+export interface Logger {
+  /**
+   * Log at trace level (most verbose).
+   * Use for fine-grained debugging.
+   */
+  trace(message: string, metadata?: Record<string, unknown>): void;
+
+  /**
+   * Log at debug level.
+   * Use for detailed execution context.
+   */
+  debug(message: string, metadata?: Record<string, unknown>): void;
+
+  /**
+   * Log at info level.
+   * Use for cycle milestones and significant events.
+   */
+  info(message: string, metadata?: Record<string, unknown>): void;
+
+  /**
+   * Log at warn level.
+   * Use for degraded performance, retry scenarios.
+   */
+  warn(message: string, metadata?: Record<string, unknown>): void;
+
+  /**
+   * Log at error level.
+   * Use for failures requiring attention.
+   *
+   * @param message - Error description
+   * @param error - Optional Error object for stack trace
+   * @param metadata - Additional context
+   */
+  error(message: string, error?: Error, metadata?: Record<string, unknown>): void;
+
+  /**
+   * Create a child logger with additional context.
+   * Child context is merged with parent context.
+   */
+  child(context: LogContext): Logger;
+
+  /**
+   * Get the current context of this logger.
+   */
+  getContext(): LogContext;
+
+  /**
+   * Get the current log level.
+   */
+  getLevel(): LogLevel;
+
+  /**
+   * Check if a log level is enabled.
+   */
+  isLevelEnabled(level: LogLevel): boolean;
+}
+
+// ─── Logger Configuration ────────────────────────────────────────────────────
+
+/**
+ * Output format for log entries.
+ * - 'json': JSON Lines format (machine-readable)
+ * - 'text': Human-readable with timestamps
+ * - 'pretty': Colorized human-readable (for TTY)
+ */
+export type LogFormat = 'json' | 'text' | 'pretty';
+
+/**
+ * Output destination for log entries.
+ */
+export type LogOutput = 'stdout' | 'stderr' | 'file' | 'silent';
+
+/**
+ * Logger configuration options.
+ */
+export interface LoggerConfig {
+  /** Minimum log level (default: 'info') */
+  readonly level?: LogLevel;
+  /** Output format (default: 'text') */
+  readonly format?: LogFormat;
+  /** Output destination (default: 'stderr') */
+  readonly output?: LogOutput;
+  /** File path if output is 'file' */
+  readonly filePath?: string;
+  /** Initial context (propagated to all log entries) */
+  readonly context?: LogContext;
+  /** Include timestamps in text format (default: true) */
+  readonly timestamps?: boolean;
+  /** Include stack traces for errors (default: true in debug/trace) */
+  readonly stackTraces?: boolean;
+}

--- a/packages/core/tests/telemetry/logger.test.ts
+++ b/packages/core/tests/telemetry/logger.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Tests for structured logger implementation.
+ *
+ * @packageDocumentation
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  createLogger,
+  createSilentLogger,
+  createLoggerFromEnv,
+  getLogger,
+  setLogger,
+  resetLogger,
+} from '../../src/telemetry/logger.js';
+
+describe('Logger', () => {
+  let output: string[] = [];
+
+  beforeEach(() => {
+    output = [];
+    resetLogger();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('createLogger', () => {
+    it('should create a logger with default config', () => {
+      const logger = createLogger();
+      expect(logger).toBeDefined();
+      expect(logger.getLevel()).toBe('info');
+    });
+
+    it('should respect configured log level', () => {
+      const logger = createLogger({ level: 'debug' });
+      expect(logger.getLevel()).toBe('debug');
+    });
+
+    it('should create child logger with merged context', () => {
+      const parent = createLogger({
+        context: { cycleId: 896, repo: 'ada' },
+      });
+      const child = parent.child({ role: 'frontier' });
+
+      expect(parent.getContext()).toEqual({ cycleId: 896, repo: 'ada' });
+      expect(child.getContext()).toEqual({ cycleId: 896, repo: 'ada', role: 'frontier' });
+    });
+
+    it('child context should override parent context', () => {
+      const parent = createLogger({
+        context: { cycleId: 896, role: 'product' },
+      });
+      const child = parent.child({ role: 'frontier' });
+
+      expect(child.getContext()).toEqual({ cycleId: 896, role: 'frontier' });
+    });
+  });
+
+  describe('isLevelEnabled', () => {
+    it('should return true for same or higher levels', () => {
+      const logger = createLogger({ level: 'info' });
+
+      expect(logger.isLevelEnabled('error')).toBe(true);
+      expect(logger.isLevelEnabled('warn')).toBe(true);
+      expect(logger.isLevelEnabled('info')).toBe(true);
+      expect(logger.isLevelEnabled('debug')).toBe(false);
+      expect(logger.isLevelEnabled('trace')).toBe(false);
+    });
+
+    it('should enable all levels at trace', () => {
+      const logger = createLogger({ level: 'trace' });
+
+      expect(logger.isLevelEnabled('error')).toBe(true);
+      expect(logger.isLevelEnabled('warn')).toBe(true);
+      expect(logger.isLevelEnabled('info')).toBe(true);
+      expect(logger.isLevelEnabled('debug')).toBe(true);
+      expect(logger.isLevelEnabled('trace')).toBe(true);
+    });
+
+    it('should only enable error at error level', () => {
+      const logger = createLogger({ level: 'error' });
+
+      expect(logger.isLevelEnabled('error')).toBe(true);
+      expect(logger.isLevelEnabled('warn')).toBe(false);
+      expect(logger.isLevelEnabled('info')).toBe(false);
+      expect(logger.isLevelEnabled('debug')).toBe(false);
+      expect(logger.isLevelEnabled('trace')).toBe(false);
+    });
+  });
+
+  describe('createSilentLogger', () => {
+    it('should create a logger that produces no output', () => {
+      const logger = createSilentLogger();
+
+      // Should not throw
+      logger.info('test message');
+      logger.error('error message', new Error('test'));
+      logger.debug('debug message');
+    });
+  });
+
+  describe('JSON format', () => {
+    it('should produce valid JSON output', () => {
+      // Capture stderr
+      const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+        output.push(String(chunk).trim());
+        return true;
+      });
+
+      const logger = createLogger({
+        level: 'info',
+        format: 'json',
+        output: 'stderr',
+        context: { cycleId: 896, role: 'frontier' },
+      });
+
+      logger.info('Test message', { key: 'value' });
+
+      expect(output.length).toBe(1);
+      const parsed = JSON.parse(output[0]);
+
+      expect(parsed.level).toBe('info');
+      expect(parsed.message).toBe('Test message');
+      expect(parsed.context.cycleId).toBe(896);
+      expect(parsed.context.role).toBe('frontier');
+      expect(parsed.metadata.key).toBe('value');
+      expect(parsed.timestamp).toBeDefined();
+
+      stderrWrite.mockRestore();
+    });
+
+    it('should include error details in JSON', () => {
+      const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+        output.push(String(chunk).trim());
+        return true;
+      });
+
+      const logger = createLogger({
+        level: 'error',
+        format: 'json',
+        output: 'stderr',
+        stackTraces: true,
+      });
+
+      const error = new Error('Test error');
+      logger.error('Operation failed', error, { operation: 'test' });
+
+      expect(output.length).toBe(1);
+      const parsed = JSON.parse(output[0]);
+
+      expect(parsed.level).toBe('error');
+      expect(parsed.message).toBe('Operation failed');
+      expect(parsed.error.name).toBe('Error');
+      expect(parsed.error.message).toBe('Test error');
+      expect(parsed.error.stack).toBeDefined();
+      expect(parsed.metadata.operation).toBe('test');
+
+      stderrWrite.mockRestore();
+    });
+  });
+
+  describe('text format', () => {
+    it('should produce human-readable output', () => {
+      const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+        output.push(String(chunk).trim());
+        return true;
+      });
+
+      const logger = createLogger({
+        level: 'info',
+        format: 'text',
+        output: 'stderr',
+        context: { cycleId: 896, role: 'frontier' },
+        timestamps: false,
+      });
+
+      logger.info('Cycle started', { memoryVersion: 45 });
+
+      expect(output.length).toBe(1);
+      expect(output[0]).toContain('INFO');
+      expect(output[0]).toContain('[C896/frontier]');
+      expect(output[0]).toContain('Cycle started');
+      expect(output[0]).toContain('memoryVersion=45');
+
+      stderrWrite.mockRestore();
+    });
+  });
+
+  describe('level filtering', () => {
+    it('should not log below configured level', () => {
+      const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+        output.push(String(chunk).trim());
+        return true;
+      });
+
+      const logger = createLogger({
+        level: 'warn',
+        format: 'json',
+        output: 'stderr',
+      });
+
+      logger.trace('trace message');
+      logger.debug('debug message');
+      logger.info('info message');
+      logger.warn('warn message');
+      logger.error('error message');
+
+      // Only warn and error should be logged
+      expect(output.length).toBe(2);
+      expect(JSON.parse(output[0]).level).toBe('warn');
+      expect(JSON.parse(output[1]).level).toBe('error');
+
+      stderrWrite.mockRestore();
+    });
+  });
+
+  describe('global logger', () => {
+    it('should return same instance on repeated calls', () => {
+      const logger1 = getLogger();
+      const logger2 = getLogger();
+      expect(logger1).toBe(logger2);
+    });
+
+    it('should allow setting custom global logger', () => {
+      const customLogger = createLogger({ level: 'debug' });
+      setLogger(customLogger);
+      expect(getLogger()).toBe(customLogger);
+    });
+
+    it('should reset to new instance after resetLogger', () => {
+      const logger1 = getLogger();
+      resetLogger();
+      const logger2 = getLogger();
+      expect(logger1).not.toBe(logger2);
+    });
+  });
+
+  describe('createLoggerFromEnv', () => {
+    it('should use environment variables', () => {
+      const originalLevel = process.env.ADA_LOG_LEVEL;
+      const originalFormat = process.env.ADA_LOG_FORMAT;
+
+      process.env.ADA_LOG_LEVEL = 'debug';
+      process.env.ADA_LOG_FORMAT = 'json';
+
+      const logger = createLoggerFromEnv();
+      expect(logger.getLevel()).toBe('debug');
+
+      // Restore
+      if (originalLevel !== undefined) {
+        process.env.ADA_LOG_LEVEL = originalLevel;
+      } else {
+        delete process.env.ADA_LOG_LEVEL;
+      }
+      if (originalFormat !== undefined) {
+        process.env.ADA_LOG_FORMAT = originalFormat;
+      } else {
+        delete process.env.ADA_LOG_FORMAT;
+      }
+    });
+
+    it('should fall back to defaults when env not set', () => {
+      const originalLevel = process.env.ADA_LOG_LEVEL;
+      delete process.env.ADA_LOG_LEVEL;
+
+      const logger = createLoggerFromEnv({ level: 'warn' });
+      expect(logger.getLevel()).toBe('warn');
+
+      if (originalLevel !== undefined) {
+        process.env.ADA_LOG_LEVEL = originalLevel;
+      }
+    });
+  });
+});
+
+describe('Logger integration', () => {
+  it('should support typical dispatch cycle logging pattern', () => {
+    const output: string[] = [];
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      output.push(String(chunk).trim());
+      return true;
+    });
+
+    // Create logger for dispatch cycle
+    const logger = createLogger({
+      level: 'info',
+      format: 'json',
+      output: 'stderr',
+    });
+
+    // Start of cycle
+    const cycleLogger = logger.child({ cycleId: 896, role: 'frontier', sessionId: 'sess-123' });
+
+    cycleLogger.info('Cycle started', { memoryVersion: 45 });
+
+    // Phase logging
+    const phaseLogger = cycleLogger.child({ phase: 'context_load' });
+    phaseLogger.debug('Loading memory bank');
+    phaseLogger.info('Memory loaded', { entries: 42 });
+
+    // Action execution
+    cycleLogger.info('Executing action', { action: 'create_logger_impl' });
+
+    // Completion
+    cycleLogger.info('Cycle completed', { durationMs: 3500, success: true });
+
+    // Verify output structure
+    expect(output.length).toBeGreaterThanOrEqual(3); // debug filtered at info level
+    const entries = output.map(line => JSON.parse(line));
+
+    // All entries should have base context
+    for (const entry of entries) {
+      expect(entry.context.cycleId).toBe(896);
+      expect(entry.context.role).toBe('frontier');
+      expect(entry.context.sessionId).toBe('sess-123');
+    }
+
+    stderrWrite.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 implementation of SaaS Observability Spec (C886).

Adds a structured logging system to `@ada-ai/core` with support for machine-readable JSON output, human-readable text/pretty formats, and context propagation for distributed tracing integration.

## Type of Change

- [x] feat — New feature

## Related Issues

Relates to #186 (Structured Logging with JSON Format Option)
Relates to #178 (Distributed Tracing for SaaS Operations)
Part of C886 SaaS Observability Spec

## Changes Made

### New Files
- `packages/core/src/telemetry/index.ts` — Module barrel exports
- `packages/core/src/telemetry/types.ts` — LogLevel, LogContext, LogEntry, Logger interface, LoggerConfig
- `packages/core/src/telemetry/logger.ts` — Logger implementation with JSON/text/pretty formatters
- `packages/core/tests/telemetry/logger.test.ts` — 18 tests covering all functionality

### Modified Files
- `packages/core/src/index.ts` — Export telemetry module

### Features
- **Structured JSON logging** — JSONL output for machine parsing and log aggregation
- **Human-readable formats** — `text` (plain) and `pretty` (ANSI colors)
- **Context propagation** — Child loggers inherit and extend context (cycleId, role, sessionId, traceId)
- **Log level filtering** — trace/debug/info/warn/error with numeric comparison
- **Environment configuration** — `ADA_LOG_LEVEL`, `ADA_LOG_FORMAT` env vars
- **Error handling** — Proper error object serialization with optional stack traces
- **Global logger** — `getLogger()`/`setLogger()` singleton pattern

### Example Usage

```typescript
import { createLogger } from '@ada-ai/core';

const logger = createLogger({ format: 'json', level: 'info' });
const cycleLogger = logger.child({ cycleId: 896, role: 'frontier' });

cycleLogger.info('Cycle started', { memoryVersion: 45 });
// Output: {"timestamp":"...","level":"info","message":"Cycle started",...}
```

## Testing

- [x] 18 tests added
- [x] All tests passing
- [x] TypeScript strict mode compliance
- [x] ESLint clean

## Checklist

- [x] PR title follows conventional commit format
- [x] Tests included for new functionality
- [x] Documentation updated (JSDoc comments)
- [x] No breaking changes

---

*🌌 The Frontier (C896)*