### PR TITLE
feat(cli): add --verbose and --json global flags for structured logging

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,12 @@
  *   ada run        Execute one dispatch cycle
  *   ada status     Show rotation state and last actions
  *   ada config     View/edit agent configuration
+ *
+ * Output Modes (per Design Spec C892):
+ *   (default)      Clean output for developers
+ *   --verbose      Detailed output with timestamps and debug info
+ *   --json         JSON Lines output for machine parsing
+ *   --quiet        Minimal output (warnings/errors only)
  */
 
 import { Command } from 'commander';
@@ -32,6 +38,7 @@ import { terminalCommand } from './commands/terminal.js';
 import { playbookCommand } from './commands/playbook.js';
 import { validateCommand } from './commands/validate.js';
 import { showBanner } from './lib/banner.js';
+import { initCliLogger } from './lib/logger.js';
 
 const VERSION = '1.0.0-alpha';
 
@@ -42,9 +49,21 @@ program
   .description('🤖 Autonomous Dev Agents — AI agent teams for any repo')
   .version(VERSION, '-v, --version', 'Output the current version')
   .option('--banner', 'Show the ADA banner')
+  .option('--verbose', 'Enable verbose output with timestamps and debug info')
+  .option('--json', 'Output in JSON Lines format (machine-readable)')
+  .option('--quiet', 'Minimal output (warnings and errors only)')
   .hook('preAction', (thisCommand) => {
-    // Show banner if --banner flag is passed
-    if (thisCommand.opts().banner) {
+    const opts = thisCommand.opts();
+
+    // Initialize logger with output mode flags
+    initCliLogger({
+      verbose: opts.verbose,
+      json: opts.json,
+      quiet: opts.quiet,
+    });
+
+    // Show banner if --banner flag is passed (unless JSON mode)
+    if (opts.banner && !opts.json) {
       showBanner({ force: true });
     }
   });

--- a/packages/cli/src/lib/__tests__/logger.test.ts
+++ b/packages/cli/src/lib/__tests__/logger.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @ada/cli — CLI Logger Tests
+ *
+ * Tests for the CLI logger module.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getOutputMode,
+  initCliLogger,
+  getCliLogger,
+  isJsonMode,
+  isVerboseMode,
+  isQuietMode,
+  getOutputModeActive,
+  createCommandLogger,
+} from '../logger.js';
+
+describe('CLI Logger', () => {
+  describe('getOutputMode', () => {
+    it('returns "clean" by default', () => {
+      expect(getOutputMode({})).toBe('clean');
+    });
+
+    it('returns "json" when json flag is set', () => {
+      expect(getOutputMode({ json: true })).toBe('json');
+    });
+
+    it('returns "verbose" when verbose flag is set', () => {
+      expect(getOutputMode({ verbose: true })).toBe('verbose');
+    });
+
+    it('returns "quiet" when quiet flag is set', () => {
+      expect(getOutputMode({ quiet: true })).toBe('quiet');
+    });
+
+    it('json takes precedence over verbose', () => {
+      expect(getOutputMode({ json: true, verbose: true })).toBe('json');
+    });
+
+    it('json takes precedence over quiet', () => {
+      expect(getOutputMode({ json: true, quiet: true })).toBe('json');
+    });
+
+    it('verbose takes precedence over quiet', () => {
+      expect(getOutputMode({ verbose: true, quiet: true })).toBe('verbose');
+    });
+  });
+
+  describe('initCliLogger', () => {
+    it('initializes with default clean mode', () => {
+      const logger = initCliLogger();
+      expect(logger).toBeDefined();
+      expect(getOutputModeActive()).toBe('clean');
+    });
+
+    it('initializes with json mode', () => {
+      const logger = initCliLogger({ json: true });
+      expect(logger).toBeDefined();
+      expect(getOutputModeActive()).toBe('json');
+      expect(isJsonMode()).toBe(true);
+    });
+
+    it('initializes with verbose mode', () => {
+      const logger = initCliLogger({ verbose: true });
+      expect(logger).toBeDefined();
+      expect(getOutputModeActive()).toBe('verbose');
+      expect(isVerboseMode()).toBe(true);
+    });
+
+    it('initializes with quiet mode', () => {
+      const logger = initCliLogger({ quiet: true });
+      expect(logger).toBeDefined();
+      expect(getOutputModeActive()).toBe('quiet');
+      expect(isQuietMode()).toBe(true);
+    });
+  });
+
+  describe('getCliLogger', () => {
+    it('returns initialized logger', () => {
+      initCliLogger({ verbose: true });
+      const logger = getCliLogger();
+      expect(logger).toBeDefined();
+      expect(typeof logger.info).toBe('function');
+      expect(typeof logger.debug).toBe('function');
+      expect(typeof logger.warn).toBe('function');
+      expect(typeof logger.error).toBe('function');
+    });
+
+    it('auto-initializes if not already done', () => {
+      // Force a fresh state by initializing with different options
+      initCliLogger({});
+      const logger = getCliLogger();
+      expect(logger).toBeDefined();
+    });
+  });
+
+  describe('createCommandLogger', () => {
+    it('creates child logger with context', () => {
+      initCliLogger();
+      const logger = createCommandLogger({
+        cycleId: 900,
+        role: 'engineering',
+        command: 'dispatch',
+      });
+
+      expect(logger).toBeDefined();
+      const context = logger.getContext();
+      expect(context.cycleId).toBe(900);
+      expect(context.role).toBe('engineering');
+      expect(context.command).toBe('dispatch');
+    });
+
+    it('inherits parent logger mode', () => {
+      initCliLogger({ json: true });
+      const logger = createCommandLogger({ cycleId: 900 });
+      expect(logger).toBeDefined();
+      // Logger should still be in JSON mode
+      expect(isJsonMode()).toBe(true);
+    });
+  });
+
+  describe('mode helpers', () => {
+    it('isJsonMode returns correct state', () => {
+      initCliLogger({});
+      expect(isJsonMode()).toBe(false);
+
+      initCliLogger({ json: true });
+      expect(isJsonMode()).toBe(true);
+    });
+
+    it('isVerboseMode returns correct state', () => {
+      initCliLogger({});
+      expect(isVerboseMode()).toBe(false);
+
+      initCliLogger({ verbose: true });
+      expect(isVerboseMode()).toBe(true);
+    });
+
+    it('isQuietMode returns correct state', () => {
+      initCliLogger({});
+      expect(isQuietMode()).toBe(false);
+
+      initCliLogger({ quiet: true });
+      expect(isQuietMode()).toBe(true);
+    });
+  });
+});

--- a/packages/cli/src/lib/logger.ts
+++ b/packages/cli/src/lib/logger.ts
@@ -1,0 +1,186 @@
+/**
+ * @ada/cli — CLI Logger Module
+ *
+ * Wraps the @ada-ai/core structured logger with CLI-specific configuration.
+ * Supports --verbose and --json global flags per Design Spec (C892).
+ *
+ * @packageDocumentation
+ */
+
+import {
+  createLogger,
+  setLogger,
+  type Logger,
+  type LoggerConfig,
+} from '@ada-ai/core';
+
+// ─── CLI Output Configuration ────────────────────────────────────────────────
+
+/**
+ * CLI output mode based on flags.
+ * - clean: Default, minimal output (info level)
+ * - verbose: Detailed output with timestamps (debug level)
+ * - json: JSON Lines for machine parsing (info level, JSON format)
+ * - quiet: Minimal warnings/errors only (warn level)
+ */
+export type OutputMode = 'clean' | 'verbose' | 'json' | 'quiet';
+
+/**
+ * CLI output options from global flags.
+ */
+export interface OutputOptions {
+  /** Enable verbose output (--verbose) */
+  verbose?: boolean;
+  /** Enable JSON output (--json) */
+  json?: boolean;
+  /** Enable quiet mode (--quiet) */
+  quiet?: boolean;
+}
+
+/**
+ * Determine output mode from CLI flags.
+ * Flag precedence: --json > --verbose > --quiet > clean
+ */
+export function getOutputMode(options: OutputOptions): OutputMode {
+  if (options.json) return 'json';
+  if (options.verbose) return 'verbose';
+  if (options.quiet) return 'quiet';
+  return 'clean';
+}
+
+// ─── Logger Configuration ────────────────────────────────────────────────────
+
+/**
+ * Map output mode to logger configuration.
+ */
+function getLoggerConfig(mode: OutputMode): LoggerConfig {
+  const baseConfig: LoggerConfig = {
+    output: 'stderr',
+    timestamps: mode === 'verbose',
+  };
+
+  switch (mode) {
+    case 'json':
+      return {
+        ...baseConfig,
+        format: 'json',
+        level: 'info',
+        timestamps: true, // Always include in JSON
+      };
+    case 'verbose':
+      return {
+        ...baseConfig,
+        format: 'pretty', // Colorized for TTY
+        level: 'debug',
+        timestamps: true,
+      };
+    case 'quiet':
+      return {
+        ...baseConfig,
+        format: 'text',
+        level: 'warn',
+        timestamps: false,
+      };
+    case 'clean':
+    default:
+      return {
+        ...baseConfig,
+        format: 'text',
+        level: 'info',
+        timestamps: false,
+      };
+  }
+}
+
+// ─── CLI Logger Instance ─────────────────────────────────────────────────────
+
+let cliLogger: Logger | null = null;
+let currentMode: OutputMode = 'clean';
+
+/**
+ * Initialize the CLI logger with the specified output options.
+ * Call this early in the CLI lifecycle (e.g., in preAction hook).
+ *
+ * @param options - Output options from global CLI flags
+ * @returns Configured logger instance
+ *
+ * @example
+ * ```typescript
+ * // In CLI preAction hook:
+ * const logger = initCliLogger({
+ *   verbose: thisCommand.opts().verbose,
+ *   json: thisCommand.opts().json
+ * });
+ * ```
+ */
+export function initCliLogger(options: OutputOptions = {}): Logger {
+  currentMode = getOutputMode(options);
+  const config = getLoggerConfig(currentMode);
+  cliLogger = createLogger(config);
+
+  // Also set as global logger for core library
+  setLogger(cliLogger);
+
+  return cliLogger;
+}
+
+/**
+ * Get the CLI logger instance.
+ * Initializes with default config if not already initialized.
+ */
+export function getCliLogger(): Logger {
+  if (!cliLogger) {
+    return initCliLogger();
+  }
+  return cliLogger;
+}
+
+/**
+ * Create a child logger with context for a specific command.
+ * Used to add cycle/role context to command output.
+ *
+ * @param context - Context to add to the logger
+ * @returns Child logger with context
+ *
+ * @example
+ * ```typescript
+ * const logger = createCommandLogger({ cycleId: 900, role: 'engineering' });
+ * logger.info('Cycle started');
+ * ```
+ */
+export function createCommandLogger(context: {
+  cycleId?: number;
+  role?: string;
+  command?: string;
+}): Logger {
+  return getCliLogger().child(context);
+}
+
+/**
+ * Get the current output mode.
+ */
+export function getOutputModeActive(): OutputMode {
+  return currentMode;
+}
+
+/**
+ * Check if JSON output mode is active.
+ * Useful for commands that need to switch between JSON and formatted output.
+ */
+export function isJsonMode(): boolean {
+  return currentMode === 'json';
+}
+
+/**
+ * Check if verbose mode is active.
+ */
+export function isVerboseMode(): boolean {
+  return currentMode === 'verbose';
+}
+
+/**
+ * Check if quiet mode is active.
+ */
+export function isQuietMode(): boolean {
+  return currentMode === 'quiet';
+}


### PR DESCRIPTION
## Summary

Integrates the @ada-ai/core structured logger (PR #216) into the CLI per Design Spec (C892).

## Changes

- Add global `--verbose`, `--json`, `--quiet` flags to `ada` CLI
- Create `packages/cli/src/lib/logger.ts` — CLI logger module wrapping core logger
- Initialize logger in preAction hook based on flags
- Add 18 unit tests for logger module

## Output Modes

| Flag | Mode | Audience | Use Case |
|------|------|----------|----------|
| (none) | Clean | Developers | Day-to-day use, minimal noise |
| `--verbose` | Verbose | Operators | Debugging, monitoring |
| `--json` | JSON Lines | Machines | Log aggregation, parsing |
| `--quiet` | Quiet | CI/Scripts | Warnings/errors only |

## Flag Precedence

- `--json` always wins (machine-parseable, no formatting)
- `--verbose` adds detail to human output
- `--quiet` suppresses info-level

## Testing

```bash
npx vitest run src/lib/__tests__/logger.test.ts
# 18 tests passing
```

## Dependencies

**⚠️ This PR builds on top of PR #216** (structured logger core implementation).
Base branch is `ada/c896-frontier-structured-logger`.

Once #216 is merged, this PR should be rebased onto main.

## Related

- Relates to #186 (Structured Logging)
- Relates to #178 (Distributed Tracing)
- Implements Design Spec C892 (Observability Output UX)

---

**Author:** ⚙️ Engineering (C900)