### PR TITLE
fix(cli): use local tsx binary in E2E test harness (#230)

### DIFF
--- a/packages/cli/tests/e2e/harness.ts
+++ b/packages/cli/tests/e2e/harness.ts
@@ -50,6 +50,9 @@ export class Sandbox {
   /** Whether the sandbox has been cleaned up */
   private cleaned = false;
 
+  /** Path to the tsx binary (resolved from monorepo root) */
+  private readonly tsxPath: string;
+
   constructor(options: SandboxOptions = {}) {
     const {
       git = true,
@@ -62,8 +65,12 @@ export class Sandbox {
     this.path = mkdtempSync(join(tmpdir(), 'ada-e2e-'));
 
     // Resolve CLI path from monorepo root
-    // During tests, we use ts-node to run the CLI source directly
+    // During tests, we use tsx to run the CLI source directly
     this.cliPath = resolve(__dirname, '../../src/index.ts');
+
+    // Resolve tsx binary path - use local node_modules instead of npx for reliability
+    // This avoids potential npx caching/download issues in CI environments
+    this.tsxPath = resolve(__dirname, '../../../../node_modules/.bin/tsx');
 
     // Initialize git if requested
     if (git) {
@@ -104,7 +111,9 @@ export class Sandbox {
       const stdout: string[] = [];
       const stderr: string[] = [];
 
-      const proc = spawn('npx', ['tsx', this.cliPath, ...args], {
+      // Use local tsx binary directly instead of npx for reliability in CI
+      // npx can have caching/download issues that cause intermittent failures
+      const proc = spawn(this.tsxPath, [this.cliPath, ...args], {
         cwd: this.path,
         env: {
           ...process.env,


### PR DESCRIPTION
## Summary

Fixes E2E test failures in CI by using the local tsx binary directly instead of going through npx.

## Problem

E2E tests were failing intermittently in CI with "expected false to be true" errors. The failing tests:
- `observe.e2e.test.ts`: `--help flag` and `uninitialized repository` tests
- `validate.e2e.test.ts`: `displays validation header` (beforeEach runs `ada init`)

**Root cause analysis update:** Initial diagnosis blamed Node 22.x, but tests actually fail on both Node 20.x and Node 22.x in CI (pass locally on both).

The real issue: the test harness used `spawn('npx', ['tsx', ...])` which has inconsistent behavior in CI environments due to npx's caching and resolution logic.

## Changes Made

Updated `packages/cli/tests/e2e/harness.ts`:
- Added `tsxPath` property that resolves to local `node_modules/.bin/tsx`
- Changed spawn call to use local tsx binary directly instead of npx
- Added comments explaining the reliability improvement

## Why This Fixes It

- `npx` can have caching/download issues that cause different behavior between runs
- Local node_modules binary is deterministic — uses exact version from `npm ci`
- Eliminates environment-dependent resolution logic

## Testing

- All E2E tests pass locally (Node 20 and 22)
- CI run will verify the fix in GitHub Actions environment

## Lesson Learned

**L560:** When spawning CLI tools in test harnesses, use local node_modules binaries directly instead of npx. npx has caching/resolution behaviors that can cause intermittent CI failures.

---
🔍 *QA (Cycle 939)*