### PR TITLE
fix(core,cli,web): add vitest OOM prevention settings

### DIFF
--- a/apps/waitlist/package.json
+++ b/apps/waitlist/package.json
@@ -9,8 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run",
-    "test:watch": "vitest",
+    "test": "NODE_OPTIONS='--max-old-space-size=4096' vitest run",
+    "test:watch": "NODE_OPTIONS='--max-old-space-size=4096' vitest",
     "typecheck": "tsc -p tsconfig.app.json --noEmit"
   },
   "dependencies": {

--- a/apps/waitlist/vitest.config.ts
+++ b/apps/waitlist/vitest.config.ts
@@ -9,6 +9,16 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    // OOM Prevention (Issue #236): Limit parallelism and memory
+    pool: "threads",
+    poolOptions: {
+      threads: {
+        maxThreads: 2, // Down from 8-12 default, prevents 13GB+ RAM usage
+        minThreads: 1,
+      },
+    },
+    isolate: true, // Ensure test isolation between files
+    clearMocks: true, // Clear mocks after each test
   },
   resolve: {
     alias: { "@": path.resolve(__dirname, "./src") },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,9 +15,9 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --passWithNoTests",
-    "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage",
+    "test": "NODE_OPTIONS='--max-old-space-size=4096' vitest run --passWithNoTests",
+    "test:watch": "NODE_OPTIONS='--max-old-space-size=4096' vitest",
+    "test:coverage": "NODE_OPTIONS='--max-old-space-size=4096' vitest run --coverage",
     "lint": "eslint src/",
     "clean": "rm -rf dist",
     "dev": "tsx src/index.ts"

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -11,6 +11,17 @@ export default defineConfig({
     // Global setup ensures @ada/core is built before E2E tests run.
     // Fixes Issue #121: stale build artifacts causing cryptic E2E failures.
     globalSetup: ['tests/e2e/setup.ts'],
+    // OOM Prevention (Issue #236): Limit parallelism and memory
+    // CLI tests are I/O heavy (subprocess spawning), limiting threads prevents RAM spikes
+    pool: 'threads',
+    poolOptions: {
+      threads: {
+        maxThreads: 2, // Down from 8-12 default, prevents 13GB+ RAM usage
+        minThreads: 1,
+      },
+    },
+    isolate: true, // Ensure test isolation between files
+    clearMocks: true, // Clear mocks after each test
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,9 +41,9 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --passWithNoTests",
-    "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage",
+    "test": "NODE_OPTIONS='--max-old-space-size=4096' vitest run --passWithNoTests",
+    "test:watch": "NODE_OPTIONS='--max-old-space-size=4096' vitest",
+    "test:coverage": "NODE_OPTIONS='--max-old-space-size=4096' vitest run --coverage",
     "lint": "eslint src/",
     "clean": "rm -rf dist"
   },

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -5,6 +5,16 @@ export default defineConfig({
     globals: false,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
+    // OOM Prevention (Issue #236): Limit parallelism and memory
+    pool: 'threads',
+    poolOptions: {
+      threads: {
+        maxThreads: 2, // Down from 8-12 default, prevents 13GB+ RAM usage
+        minThreads: 1,
+      },
+    },
+    isolate: true, // Ensure test isolation between files
+    clearMocks: true, // Clear mocks after each test
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
## Summary

Implements Vitest OOM prevention settings across all packages to prevent daily system crashes caused by test runner consuming 13GB+ RAM.

## Type of Change

- [x] fix: Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #236

## Changes Made

### Vitest Config Updates (all packages)
- Added `pool: 'threads'` with `maxThreads: 2` (down from 8-12 default)
- Added `isolate: true` for test file isolation
- Added `clearMocks: true` for automatic mock cleanup

### Package.json Script Updates
- Added `NODE_OPTIONS='--max-old-space-size=4096'` to test scripts in:
  - `packages/core/package.json`
  - `packages/cli/package.json`
  - `apps/waitlist/package.json`

## Testing

- [x] Core tests pass (1,412 tests)
- [x] Typecheck passes
- [x] Build passes

## Expected Results

- Memory usage: ~2-3GB (down from 13GB+)
- No more OOM crashes during test runs
- Stable CI/CD pipeline

## Checklist

- [x] PR title follows conventional commit format
- [x] Self-review of code completed
- [x] Comments added for non-obvious code
- [x] No new warnings introduced

---
*⚙️ The Builder (Lead Engineer) — Cycle 1080*