### PR TITLE
feat(core): implement error messages foundation per Design C1082

### DIFF
--- a/packages/core/src/errors/builder.ts
+++ b/packages/core/src/errors/builder.ts
@@ -1,0 +1,211 @@
+/**
+ * @file ErrorBuilder — fluent API for constructing AdaError instances
+ * @description Implements C1082 CLI Error Messages UX Spec
+ * @see docs/design/cli-error-messages-ux-spec-c1082.md
+ */
+
+import type { ErrorCode, ErrorContext, Suggestion } from './types.js';
+import { AdaError } from './error.js';
+
+/**
+ * Fluent builder for constructing AdaError instances.
+ *
+ * @example
+ * ```typescript
+ * throw new ErrorBuilder('ADA_NOT_INITIALIZED')
+ *   .context('dispatch start')
+ *   .detail('missingFile', 'agents/state/rotation.json')
+ *   .suggest('Run `ada init` to set up an agent team', { primary: true })
+ *   .suggest('Navigate to a directory with ADA configured')
+ *   .build();
+ * ```
+ */
+export class ErrorBuilder {
+  private readonly code: ErrorCode;
+  private messageOverride?: string;
+  private errorContext: ErrorContext = {};
+  private errorDetails: Record<string, unknown> = {};
+  private errorSuggestions: Suggestion[] = [];
+  private replaceSuggestionsFlag = false;
+  private errorCause?: Error;
+
+  constructor(code: ErrorCode) {
+    this.code = code;
+  }
+
+  /**
+   * Override the default message template.
+   */
+  message(msg: string): this {
+    this.messageOverride = msg;
+    return this;
+  }
+
+  /**
+   * Set the command context (command name).
+   */
+  context(command: string): this {
+    this.errorContext.command = command;
+    return this;
+  }
+
+  /**
+   * Set the working directory context.
+   */
+  workDir(dir: string): this {
+    this.errorContext.workingDir = dir;
+    return this;
+  }
+
+  /**
+   * Set flags passed to the command.
+   */
+  flags(flags: string[]): this {
+    this.errorContext.flags = flags;
+    return this;
+  }
+
+  /**
+   * Set a missing flag (for validation errors).
+   */
+  missingFlag(flag: string): this {
+    this.errorContext.missingFlag = flag;
+    return this;
+  }
+
+  /**
+   * Set git status in context.
+   */
+  git(hasGit: boolean): this {
+    this.errorContext.hasGit = hasGit;
+    return this;
+  }
+
+  /**
+   * Set ADA initialization status in context.
+   */
+  ada(hasAda: boolean): this {
+    this.errorContext.hasAda = hasAda;
+    return this;
+  }
+
+  /**
+   * Add a detail key-value pair.
+   */
+  detail(key: string, value: unknown): this {
+    this.errorDetails[key] = value;
+    return this;
+  }
+
+  /**
+   * Add multiple details at once.
+   */
+  details(details: Record<string, unknown>): this {
+    Object.assign(this.errorDetails, details);
+    return this;
+  }
+
+  /**
+   * Add a suggestion.
+   *
+   * @param action - The suggestion text
+   * @param options - Optional: { primary: boolean, command: string }
+   */
+  suggest(
+    action: string,
+    options?: { primary?: boolean; command?: string }
+  ): this {
+    const suggestion: Suggestion = {
+      action,
+      primary: options?.primary ?? false,
+    };
+    if (options?.command) {
+      suggestion.command = options.command;
+    }
+    this.errorSuggestions.push(suggestion);
+    return this;
+  }
+
+  /**
+   * Add a primary suggestion (shorthand for suggest with primary: true).
+   */
+  suggestPrimary(action: string, command?: string): this {
+    if (command) {
+      return this.suggest(action, { primary: true, command });
+    }
+    return this.suggest(action, { primary: true });
+  }
+
+  /**
+   * Replace default suggestions instead of merging.
+   */
+  replaceSuggestions(): this {
+    this.replaceSuggestionsFlag = true;
+    return this;
+  }
+
+  /**
+   * Set the cause (original error).
+   */
+  cause(error: Error): this {
+    this.errorCause = error;
+    return this;
+  }
+
+  /**
+   * Build and return the AdaError instance.
+   */
+  build(): AdaError {
+    const options: {
+      message?: string;
+      details?: Record<string, unknown>;
+      context?: ErrorContext;
+      suggestions?: Suggestion[];
+      replaceSuggestions?: boolean;
+      cause?: Error;
+    } = {};
+
+    if (this.messageOverride) {
+      options.message = this.messageOverride;
+    }
+    if (Object.keys(this.errorDetails).length > 0) {
+      options.details = this.errorDetails;
+    }
+    if (Object.keys(this.errorContext).length > 0) {
+      options.context = this.errorContext;
+    }
+    if (this.errorSuggestions.length > 0) {
+      options.suggestions = this.errorSuggestions;
+    }
+    if (this.replaceSuggestionsFlag) {
+      options.replaceSuggestions = true;
+    }
+    if (this.errorCause) {
+      options.cause = this.errorCause;
+    }
+
+    return new AdaError(this.code, options);
+  }
+
+  /**
+   * Build and throw the error immediately.
+   */
+  throw(): never {
+    throw this.build();
+  }
+}
+
+/**
+ * Factory function for creating an ErrorBuilder.
+ * Shorthand for `new ErrorBuilder(code)`.
+ *
+ * @example
+ * ```typescript
+ * throw adaError('ADA_NOT_INITIALIZED')
+ *   .detail('missingFile', 'rotation.json')
+ *   .build();
+ * ```
+ */
+export function adaError(code: ErrorCode): ErrorBuilder {
+  return new ErrorBuilder(code);
+}

--- a/packages/core/src/errors/error.ts
+++ b/packages/core/src/errors/error.ts
@@ -1,0 +1,184 @@
+/**
+ * @file AdaError class — structured error with actionable suggestions
+ * @description Implements C1082 CLI Error Messages UX Spec
+ * @see docs/design/cli-error-messages-ux-spec-c1082.md
+ */
+
+import type { ErrorCode, ErrorContext, Suggestion } from './types.js';
+import { getErrorDefinition } from './registry.js';
+
+/**
+ * Structured error class for ADA CLI.
+ *
+ * Provides:
+ * - Error code for programmatic handling
+ * - Human-readable message with context
+ * - Actionable suggestions for resolution
+ * - Documentation link
+ * - Appropriate exit code
+ *
+ * @example
+ * ```typescript
+ * throw new AdaError('ADA_NOT_INITIALIZED', {
+ *   details: { missingFile: 'agents/state/rotation.json' },
+ *   context: { command: 'dispatch start', workingDir: process.cwd() },
+ * });
+ * ```
+ */
+export class AdaError extends Error {
+  /** Error code (e.g., ADA_NOT_INITIALIZED) */
+  readonly code: ErrorCode;
+
+  /** Error category (config, runtime, network, validation) */
+  readonly category: string;
+
+  /** Additional details about the error */
+  readonly details: Record<string, unknown>;
+
+  /** Suggestions for resolving the error */
+  readonly suggestions: Suggestion[];
+
+  /** URL to documentation */
+  readonly docs: string;
+
+  /** Exit code for CLI (1-6) */
+  readonly exitCode: number;
+
+  /** Command context when error occurred */
+  readonly context?: ErrorContext;
+
+  constructor(
+    code: ErrorCode,
+    options: {
+      /** Override the default message template */
+      message?: string;
+      /** Additional details (e.g., missingFile, invalidField) */
+      details?: Record<string, unknown>;
+      /** Command context */
+      context?: ErrorContext;
+      /** Additional suggestions (merged with defaults) */
+      suggestions?: Suggestion[];
+      /** Replace default suggestions entirely */
+      replaceSuggestions?: boolean;
+      /** Original error that caused this */
+      cause?: Error;
+    } = {}
+  ) {
+    const definition = getErrorDefinition(code);
+    const message = options.message ?? definition.template;
+
+    super(message, { cause: options.cause });
+
+    this.name = 'AdaError';
+    this.code = code;
+    this.category = definition.category;
+    this.details = options.details ?? {};
+    this.docs = definition.docs;
+    this.exitCode = definition.exitCode;
+    if (options.context) {
+      this.context = options.context;
+    }
+
+    // Merge suggestions: defaults + custom, or replace entirely
+    if (options.replaceSuggestions && options.suggestions) {
+      this.suggestions = options.suggestions;
+    } else {
+      this.suggestions = [
+        ...definition.defaultSuggestions,
+        ...(options.suggestions ?? []),
+      ];
+    }
+
+    // Capture stack trace properly
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, AdaError);
+    }
+  }
+
+  /**
+   * Get the primary (most likely) suggestion.
+   */
+  get primarySuggestion(): Suggestion | undefined {
+    return this.suggestions.find((s) => s.primary);
+  }
+
+  /**
+   * Get secondary suggestions.
+   */
+  get secondarySuggestions(): Suggestion[] {
+    return this.suggestions.filter((s) => !s.primary);
+  }
+
+  /**
+   * Convert to JSON for structured output.
+   */
+  toJSON(): {
+    ok: false;
+    error: {
+      code: ErrorCode;
+      message: string;
+      details: Record<string, unknown>;
+      suggestions: Suggestion[];
+      docs: string;
+      exitCode: number;
+      context?: ErrorContext;
+    };
+  } {
+    return {
+      ok: false,
+      error: {
+        code: this.code,
+        message: this.message,
+        details: this.details,
+        suggestions: this.suggestions,
+        docs: this.docs,
+        exitCode: this.exitCode,
+        ...(this.context && { context: this.context }),
+      },
+    };
+  }
+
+  /**
+   * Create an AdaError from an unknown error.
+   * Wraps non-AdaError exceptions with ADA_UNKNOWN_ERROR.
+   */
+  static from(
+    error: unknown,
+    options?: {
+      context?: ErrorContext;
+      fallbackCode?: ErrorCode;
+    }
+  ): AdaError {
+    if (error instanceof AdaError) {
+      return error;
+    }
+
+    const code = options?.fallbackCode ?? 'ADA_UNKNOWN_ERROR';
+    const cause = error instanceof Error ? error : undefined;
+    const message = error instanceof Error ? error.message : String(error);
+
+    const errorOptions: ConstructorParameters<typeof AdaError>[1] = {
+      message,
+      details: {
+        originalError: message,
+        ...(cause?.stack && { stack: cause.stack }),
+      },
+    };
+
+    if (cause) {
+      errorOptions.cause = cause;
+    }
+    if (options?.context) {
+      errorOptions.context = options.context;
+    }
+
+    return new AdaError(code, errorOptions);
+  }
+
+  /**
+   * Check if an error is an AdaError.
+   */
+  static isAdaError(error: unknown): error is AdaError {
+    return error instanceof AdaError;
+  }
+}

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -1,0 +1,105 @@
+/**
+ * @file ADA Error Handling Module
+ * @description Structured errors with actionable suggestions for ADA CLI
+ * @see docs/design/cli-error-messages-ux-spec-c1082.md
+ *
+ * ## Overview
+ *
+ * This module provides a comprehensive error handling system for the ADA CLI.
+ * Every error includes:
+ * - A standardized error code (e.g., `ADA_NOT_INITIALIZED`)
+ * - A human-readable message explaining what went wrong
+ * - Actionable suggestions for resolution
+ * - Documentation link for more details
+ * - Appropriate exit code for scripting
+ *
+ * ## Usage
+ *
+ * ### Basic Error Throwing
+ *
+ * ```typescript
+ * import { AdaError } from '@ada-ai/core';
+ *
+ * throw new AdaError('ADA_NOT_INITIALIZED', {
+ *   details: { missingFile: 'rotation.json' },
+ * });
+ * ```
+ *
+ * ### Using ErrorBuilder (Fluent API)
+ *
+ * ```typescript
+ * import { ErrorBuilder, adaError } from '@ada-ai/core';
+ *
+ * // Long form
+ * throw new ErrorBuilder('ADA_NOT_INITIALIZED')
+ *   .context('dispatch start')
+ *   .detail('missingFile', 'rotation.json')
+ *   .suggest('Run `ada init`', { primary: true })
+ *   .build();
+ *
+ * // Short form with factory
+ * throw adaError('ADA_NOT_INITIALIZED')
+ *   .detail('missingFile', 'rotation.json')
+ *   .build();
+ * ```
+ *
+ * ### Rendering Errors
+ *
+ * ```typescript
+ * import { renderError, printError } from '@ada-ai/core';
+ *
+ * try {
+ *   // ... code that throws AdaError
+ * } catch (error) {
+ *   // Print to stderr and get exit code
+ *   const exitCode = printError(error);
+ *   process.exit(exitCode);
+ * }
+ * ```
+ *
+ * ### JSON Output
+ *
+ * ```typescript
+ * const output = renderError(error, { json: true });
+ * // { "ok": false, "error": { "code": "ADA_NOT_INITIALIZED", ... } }
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+// Types
+export type {
+  ErrorCategory,
+  ErrorCode,
+  Suggestion,
+  ErrorDefinition,
+  ErrorContext,
+  ErrorJson,
+  RenderOptions,
+} from './types.js';
+
+export { EXIT_CODES, CATEGORY_EXIT_CODES } from './types.js';
+
+// Registry
+export {
+  ERROR_REGISTRY,
+  DOCS_BASE_URL,
+  getErrorDefinition,
+  isValidErrorCode,
+} from './registry.js';
+
+// Error class
+export { AdaError } from './error.js';
+
+// Builder
+export { ErrorBuilder, adaError } from './builder.js';
+
+// Renderer
+export {
+  shouldUseColors,
+  shouldUseJson,
+  detectRenderOptions,
+  renderError,
+  printError,
+  withErrorHandler,
+} from './renderer.js';

--- a/packages/core/src/errors/registry.ts
+++ b/packages/core/src/errors/registry.ts
@@ -1,0 +1,349 @@
+/**
+ * @file Error registry for ADA CLI
+ * @description Centralized error definitions with messages, codes, and suggestions
+ * @see docs/design/cli-error-messages-ux-spec-c1082.md
+ */
+
+import type { ErrorCode, ErrorDefinition } from './types.js';
+import { EXIT_CODES } from './types.js';
+
+/**
+ * Base URL for error documentation.
+ */
+export const DOCS_BASE_URL = 'https://ada.dev/errors';
+
+/**
+ * Registry of all ADA error codes.
+ * Each error has a standardized structure for consistent UX.
+ */
+export const ERROR_REGISTRY: Record<ErrorCode, ErrorDefinition> = {
+  // ============================================
+  // Configuration Errors (exit code 3)
+  // ============================================
+
+  ADA_NOT_INITIALIZED: {
+    exitCode: EXIT_CODES.CONFIG_ERROR,
+    category: 'config',
+    template: "This directory doesn't have an ADA agent team configured",
+    docs: `${DOCS_BASE_URL}/ADA_NOT_INITIALIZED`,
+    defaultSuggestions: [
+      {
+        action: 'Run `ada init` to set up an agent team here',
+        primary: true,
+        command: 'ada init',
+      },
+      {
+        action: 'Navigate to a directory that has ADA configured',
+        primary: false,
+      },
+    ],
+  },
+
+  ADA_INVALID_CONFIG: {
+    exitCode: EXIT_CODES.CONFIG_ERROR,
+    category: 'config',
+    template: 'Invalid configuration detected',
+    docs: `${DOCS_BASE_URL}/ADA_INVALID_CONFIG`,
+    defaultSuggestions: [
+      {
+        action: 'Run `ada doctor` to diagnose and fix configuration issues',
+        primary: true,
+        command: 'ada doctor',
+      },
+      {
+        action: 'Check roster.json and rotation.json for syntax errors',
+        primary: false,
+      },
+    ],
+  },
+
+  ADA_MISSING_PLAYBOOK: {
+    exitCode: EXIT_CODES.CONFIG_ERROR,
+    category: 'config',
+    template: 'Playbook file not found for role',
+    docs: `${DOCS_BASE_URL}/ADA_MISSING_PLAYBOOK`,
+    defaultSuggestions: [
+      {
+        action: 'Create the missing playbook file',
+        primary: true,
+      },
+      {
+        action: 'Run `ada roles add` to add a role with its playbook',
+        primary: false,
+        command: 'ada roles add',
+      },
+    ],
+  },
+
+  ADA_CORRUPT_STATE: {
+    exitCode: EXIT_CODES.CONFIG_ERROR,
+    category: 'config',
+    template: 'Rotation state file is corrupted or invalid JSON',
+    docs: `${DOCS_BASE_URL}/ADA_CORRUPT_STATE`,
+    defaultSuggestions: [
+      {
+        action: 'Run `ada repair` to restore from backup',
+        primary: true,
+        command: 'ada repair',
+      },
+      {
+        action: 'Manually fix agents/state/rotation.json',
+        primary: false,
+      },
+    ],
+  },
+
+  // ============================================
+  // Runtime Errors (exit code 4)
+  // ============================================
+
+  ADA_CYCLE_IN_PROGRESS: {
+    exitCode: EXIT_CODES.RUNTIME_ERROR,
+    category: 'runtime',
+    template: 'A dispatch cycle is already in progress',
+    docs: `${DOCS_BASE_URL}/ADA_CYCLE_IN_PROGRESS`,
+    defaultSuggestions: [
+      {
+        action: 'Complete the current cycle first',
+        primary: true,
+        command: 'ada dispatch complete --action "..."',
+      },
+      {
+        action: 'If the cycle is stale, force a new start',
+        primary: false,
+        command: 'ada dispatch start --force',
+      },
+    ],
+  },
+
+  ADA_WRONG_ROLE: {
+    exitCode: EXIT_CODES.RUNTIME_ERROR,
+    category: 'runtime',
+    template: "It's not your turn in the rotation",
+    docs: `${DOCS_BASE_URL}/ADA_WRONG_ROLE`,
+    defaultSuggestions: [
+      {
+        action: 'Check current rotation with `ada status`',
+        primary: true,
+        command: 'ada status',
+      },
+      {
+        action: 'Wait for your turn or coordinate with the team',
+        primary: false,
+      },
+    ],
+  },
+
+  ADA_GIT_DIRTY: {
+    exitCode: EXIT_CODES.GIT_ERROR,
+    category: 'runtime',
+    template: 'Uncommitted changes detected in working directory',
+    docs: `${DOCS_BASE_URL}/ADA_GIT_DIRTY`,
+    defaultSuggestions: [
+      {
+        action: 'Include changes in your dispatch (they will be committed)',
+        primary: true,
+      },
+      {
+        action: 'Stash changes first',
+        primary: false,
+        command: 'git stash',
+      },
+      {
+        action: 'Commit changes separately before dispatch',
+        primary: false,
+      },
+    ],
+  },
+
+  ADA_GIT_CONFLICT: {
+    exitCode: EXIT_CODES.GIT_ERROR,
+    category: 'runtime',
+    template: 'Git merge conflict during push',
+    docs: `${DOCS_BASE_URL}/ADA_GIT_CONFLICT`,
+    defaultSuggestions: [
+      {
+        action: 'Pull latest changes and resolve conflicts',
+        primary: true,
+        command: 'git pull --rebase',
+      },
+      {
+        action: 'Then retry the push',
+        primary: false,
+        command: 'git push origin main',
+      },
+    ],
+  },
+
+  // ============================================
+  // Network Errors (exit code 5)
+  // ============================================
+
+  ADA_GITHUB_UNAUTHORIZED: {
+    exitCode: EXIT_CODES.NETWORK_ERROR,
+    category: 'network',
+    template: 'GitHub authorization failed — token invalid or expired',
+    docs: `${DOCS_BASE_URL}/ADA_GITHUB_UNAUTHORIZED`,
+    defaultSuggestions: [
+      {
+        action: 'Re-authenticate with GitHub',
+        primary: true,
+        command: 'gh auth login',
+      },
+      {
+        action: 'Set GH_TOKEN environment variable',
+        primary: false,
+      },
+      {
+        action: 'Check token scopes — needs repo access',
+        primary: false,
+      },
+    ],
+  },
+
+  ADA_GITHUB_RATE_LIMIT: {
+    exitCode: EXIT_CODES.NETWORK_ERROR,
+    category: 'network',
+    template: 'GitHub API rate limit exceeded',
+    docs: `${DOCS_BASE_URL}/ADA_GITHUB_RATE_LIMIT`,
+    defaultSuggestions: [
+      {
+        action: 'Wait for rate limit to reset (usually 1 hour)',
+        primary: true,
+      },
+      {
+        action: 'Use --skip-github flag to bypass GitHub operations',
+        primary: false,
+      },
+    ],
+  },
+
+  ADA_GITHUB_NOT_FOUND: {
+    exitCode: EXIT_CODES.NETWORK_ERROR,
+    category: 'network',
+    template: "GitHub resource not found — repo or issue doesn't exist",
+    docs: `${DOCS_BASE_URL}/ADA_GITHUB_NOT_FOUND`,
+    defaultSuggestions: [
+      {
+        action: 'Check the repository URL in your config',
+        primary: true,
+      },
+      {
+        action: 'Verify the issue/PR number exists',
+        primary: false,
+      },
+    ],
+  },
+
+  ADA_NETWORK_OFFLINE: {
+    exitCode: EXIT_CODES.NETWORK_ERROR,
+    category: 'network',
+    template: 'No internet connection available',
+    docs: `${DOCS_BASE_URL}/ADA_NETWORK_OFFLINE`,
+    defaultSuggestions: [
+      {
+        action: 'Check your internet connection',
+        primary: true,
+      },
+      {
+        action: 'Use --offline flag for local-only operations',
+        primary: false,
+      },
+    ],
+  },
+
+  // ============================================
+  // Validation Errors (exit code 2)
+  // ============================================
+
+  ADA_MISSING_ACTION: {
+    exitCode: EXIT_CODES.USAGE_ERROR,
+    category: 'validation',
+    template: 'The --action flag is required to describe what you did',
+    docs: `${DOCS_BASE_URL}/ADA_MISSING_ACTION`,
+    defaultSuggestions: [
+      {
+        action: 'Add the action flag to describe your work',
+        primary: true,
+        command: 'ada dispatch complete --action "Brief description"',
+      },
+      {
+        action: 'Add reflection for Reflexion learning',
+        primary: false,
+        command: '--reflection "What worked: ... Lesson: ..."',
+      },
+    ],
+  },
+
+  ADA_INVALID_ROLE: {
+    exitCode: EXIT_CODES.USAGE_ERROR,
+    category: 'validation',
+    template: 'Role name not found in roster',
+    docs: `${DOCS_BASE_URL}/ADA_INVALID_ROLE`,
+    defaultSuggestions: [
+      {
+        action: 'Check available roles with `ada roles list`',
+        primary: true,
+        command: 'ada roles list',
+      },
+      {
+        action: 'Add the role to roster.json',
+        primary: false,
+      },
+    ],
+  },
+
+  ADA_EMPTY_MEMORY: {
+    exitCode: EXIT_CODES.USAGE_ERROR,
+    category: 'validation',
+    template: 'Memory bank has no entries',
+    docs: `${DOCS_BASE_URL}/ADA_EMPTY_MEMORY`,
+    defaultSuggestions: [
+      {
+        action: 'Run a dispatch cycle to populate memory',
+        primary: true,
+        command: 'ada dispatch start',
+      },
+      {
+        action: 'Check if agents/memory/bank.md exists',
+        primary: false,
+      },
+    ],
+  },
+
+  // ============================================
+  // Generic Fallback
+  // ============================================
+
+  ADA_UNKNOWN_ERROR: {
+    exitCode: EXIT_CODES.GENERAL_ERROR,
+    category: 'runtime',
+    template: 'An unexpected error occurred',
+    docs: `${DOCS_BASE_URL}/ADA_UNKNOWN_ERROR`,
+    defaultSuggestions: [
+      {
+        action: 'Check the full error output for details',
+        primary: true,
+      },
+      {
+        action: 'Report this issue at https://github.com/ada-ai/ada/issues',
+        primary: false,
+      },
+    ],
+  },
+};
+
+/**
+ * Get error definition by code.
+ * Returns unknown error definition if code not found.
+ */
+export function getErrorDefinition(code: ErrorCode): ErrorDefinition {
+  return ERROR_REGISTRY[code] ?? ERROR_REGISTRY.ADA_UNKNOWN_ERROR;
+}
+
+/**
+ * Check if a code is a valid error code.
+ */
+export function isValidErrorCode(code: string): code is ErrorCode {
+  return code in ERROR_REGISTRY;
+}

--- a/packages/core/src/errors/renderer.ts
+++ b/packages/core/src/errors/renderer.ts
@@ -1,0 +1,287 @@
+/**
+ * @file Error renderer — formats AdaError for terminal output
+ * @description Implements C1082 CLI Error Messages UX Spec
+ * @see docs/design/cli-error-messages-ux-spec-c1082.md
+ */
+
+import type { RenderOptions, Suggestion } from './types.js';
+import { AdaError } from './error.js';
+
+/**
+ * ANSI color codes for terminal output.
+ */
+const ANSI = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  green: '\x1b[32m',
+  cyan: '\x1b[36m',
+  gray: '\x1b[90m',
+} as const;
+
+/**
+ * Symbols for different message types.
+ */
+const SYMBOLS = {
+  error: '✖',
+  warning: '⚠',
+  success: '✔',
+  suggestion: '💡',
+  secondary: '→',
+  docs: '📖',
+} as const;
+
+/**
+ * Check if colors should be used based on environment.
+ */
+export function shouldUseColors(): boolean {
+  // Respect NO_COLOR standard
+  if (process.env.NO_COLOR !== undefined) {
+    return false;
+  }
+
+  // Check for explicit color enable
+  if (process.env.FORCE_COLOR !== undefined) {
+    return true;
+  }
+
+  // Check CI environment
+  if (process.env.CI !== undefined) {
+    return false;
+  }
+
+  // Check if stdout is a TTY
+  return process.stdout?.isTTY ?? false;
+}
+
+/**
+ * Check if output should be JSON.
+ */
+export function shouldUseJson(): boolean {
+  return (
+    process.env.ADA_OUTPUT === 'json' ||
+    process.argv.includes('--json') ||
+    process.argv.includes('-j')
+  );
+}
+
+/**
+ * Detect render options from environment.
+ */
+export function detectRenderOptions(): RenderOptions {
+  const json = shouldUseJson();
+  const tty = process.stdout?.isTTY ?? false;
+  const ci = process.env.CI !== undefined;
+  const color = !json && shouldUseColors();
+
+  return { json, tty, color, ci };
+}
+
+/**
+ * Apply color formatting if enabled.
+ */
+function colorize(text: string, color: string, options: RenderOptions): string {
+  if (!options.color) return text;
+  return `${color}${text}${ANSI.reset}`;
+}
+
+/**
+ * Format suggestion for terminal output.
+ */
+function formatSuggestion(
+  suggestion: Suggestion,
+  options: RenderOptions
+): string {
+  const symbol = suggestion.primary ? SYMBOLS.suggestion : SYMBOLS.secondary;
+  const color = suggestion.primary ? ANSI.cyan : ANSI.dim;
+
+  let line = `  ${symbol} ${suggestion.action}`;
+
+  if (suggestion.command && options.tty) {
+    // Show command on same line if short, separate line if long
+    const commandFormatted = colorize(suggestion.command, ANSI.bold, options);
+    if (suggestion.action.length < 40) {
+      line = `  ${symbol} ${suggestion.action}:\n     ${commandFormatted}`;
+    } else {
+      line = `  ${symbol} ${suggestion.action}\n     ${commandFormatted}`;
+    }
+  } else if (suggestion.command) {
+    line += `\n     ${suggestion.command}`;
+  }
+
+  return colorize(line, color, options);
+}
+
+/**
+ * Render error for TTY terminal (colorful, with emoji).
+ */
+function renderTty(error: AdaError, options: RenderOptions): string {
+  const lines: string[] = [];
+
+  // Header: ✖ Error Title (CODE)
+  const marker = colorize(SYMBOLS.error, ANSI.red, options);
+  const title = colorize(
+    `${error.message} (${error.code})`,
+    ANSI.bold,
+    options
+  );
+  lines.push(`${marker} ${title}`);
+  lines.push('');
+
+  // Details (if any)
+  if (Object.keys(error.details).length > 0) {
+    for (const [key, value] of Object.entries(error.details)) {
+      const formattedKey = colorize(`  ${key}:`, ANSI.dim, options);
+      lines.push(`${formattedKey} ${String(value)}`);
+    }
+    lines.push('');
+  }
+
+  // Primary suggestion
+  const primary = error.primarySuggestion;
+  if (primary) {
+    lines.push(formatSuggestion(primary, options));
+    lines.push('');
+  }
+
+  // Secondary suggestions
+  const secondary = error.secondarySuggestions;
+  if (secondary.length > 0) {
+    for (const suggestion of secondary) {
+      lines.push(formatSuggestion(suggestion, options));
+    }
+    lines.push('');
+  }
+
+  // Docs link
+  const docsIcon = SYMBOLS.docs;
+  const docsLink = colorize(error.docs, ANSI.dim, options);
+  lines.push(`  ${docsIcon} Docs: ${docsLink}`);
+
+  return lines.join('\n');
+}
+
+/**
+ * Render error for non-TTY (plain text, CI-friendly).
+ */
+function renderPlain(error: AdaError, _opts: RenderOptions): string {
+  void _opts; // Reserved for future use
+  const lines: string[] = [];
+
+  // Header
+  lines.push(`ERROR [${error.code}]: ${error.message}`);
+
+  // Details
+  if (Object.keys(error.details).length > 0) {
+    for (const [key, value] of Object.entries(error.details)) {
+      lines.push(`  ${key}: ${String(value)}`);
+    }
+  }
+
+  // Suggestions
+  const primary = error.primarySuggestion;
+  if (primary) {
+    const cmd = primary.command ? ` (${primary.command})` : '';
+    lines.push(`  Fix: ${primary.action}${cmd}`);
+  }
+
+  for (const suggestion of error.secondarySuggestions) {
+    const cmd = suggestion.command ? ` (${suggestion.command})` : '';
+    lines.push(`  Alt: ${suggestion.action}${cmd}`);
+  }
+
+  // Docs
+  lines.push(`  Docs: ${error.docs}`);
+
+  return lines.join('\n');
+}
+
+/**
+ * Render error as JSON.
+ */
+function renderJson(error: AdaError, _opts: RenderOptions): string {
+  void _opts; // Reserved for future use
+  return JSON.stringify(error.toJSON(), null, 2);
+}
+
+/**
+ * Render an AdaError for terminal output.
+ *
+ * Automatically detects the appropriate format based on:
+ * - `--json` flag or `ADA_OUTPUT=json` → JSON
+ * - TTY terminal with colors → Colorful with emoji
+ * - Non-TTY or CI → Plain text
+ *
+ * @param error - The AdaError to render
+ * @param options - Optional render options (auto-detected if not provided)
+ * @returns Formatted error string
+ */
+export function renderError(
+  error: AdaError,
+  options?: Partial<RenderOptions>
+): string {
+  const opts: RenderOptions = {
+    ...detectRenderOptions(),
+    ...options,
+  };
+
+  if (opts.json) {
+    return renderJson(error, opts);
+  }
+
+  if (opts.tty && opts.color) {
+    return renderTty(error, opts);
+  }
+
+  return renderPlain(error, opts);
+}
+
+/**
+ * Print an error to stderr and return the exit code.
+ *
+ * @param error - The error to print (AdaError or any Error)
+ * @param options - Optional render options
+ * @returns The exit code to use
+ */
+export function printError(
+  error: unknown,
+  options?: Partial<RenderOptions>
+): number {
+  const adaError = AdaError.isAdaError(error)
+    ? error
+    : AdaError.from(error);
+
+  const output = renderError(adaError, options);
+  console.error(output);
+
+  return adaError.exitCode;
+}
+
+/**
+ * Error handler for CLI commands.
+ * Wraps a function to catch errors and render them properly.
+ *
+ * @example
+ * ```typescript
+ * const handler = withErrorHandler(async () => {
+ *   // command logic that might throw AdaError
+ * });
+ *
+ * handler().catch((exitCode) => process.exit(exitCode));
+ * ```
+ */
+export function withErrorHandler<T>(
+  fn: () => T | Promise<T>,
+  options?: Partial<RenderOptions>
+): () => Promise<T> {
+  return async () => {
+    try {
+      return await fn();
+    } catch (error) {
+      const exitCode = printError(error, options);
+      throw exitCode;
+    }
+  };
+}

--- a/packages/core/src/errors/types.ts
+++ b/packages/core/src/errors/types.ts
@@ -1,0 +1,137 @@
+/**
+ * @file Error types and interfaces for ADA CLI
+ * @description Implements C1082 CLI Error Messages UX Spec
+ * @see docs/design/cli-error-messages-ux-spec-c1082.md
+ */
+
+/**
+ * Error categories for ADA CLI errors.
+ * Each category has a distinct exit code range.
+ */
+export type ErrorCategory = 'config' | 'runtime' | 'network' | 'validation';
+
+/**
+ * Error codes follow pattern: ADA_<CATEGORY>_<NAME>
+ * All codes are uppercase with underscores.
+ */
+export type ErrorCode =
+  // Configuration errors (exit code 3)
+  | 'ADA_NOT_INITIALIZED'
+  | 'ADA_INVALID_CONFIG'
+  | 'ADA_MISSING_PLAYBOOK'
+  | 'ADA_CORRUPT_STATE'
+  // Runtime errors (exit code 4)
+  | 'ADA_CYCLE_IN_PROGRESS'
+  | 'ADA_WRONG_ROLE'
+  | 'ADA_GIT_DIRTY'
+  | 'ADA_GIT_CONFLICT'
+  // Network errors (exit code 5)
+  | 'ADA_GITHUB_UNAUTHORIZED'
+  | 'ADA_GITHUB_RATE_LIMIT'
+  | 'ADA_GITHUB_NOT_FOUND'
+  | 'ADA_NETWORK_OFFLINE'
+  // Validation errors (exit code 2)
+  | 'ADA_MISSING_ACTION'
+  | 'ADA_INVALID_ROLE'
+  | 'ADA_EMPTY_MEMORY'
+  // Generic fallback
+  | 'ADA_UNKNOWN_ERROR';
+
+/**
+ * Suggestion for resolving an error.
+ */
+export interface Suggestion {
+  /** Suggestion text describing the action to take */
+  action: string;
+  /** Whether this is the primary (most likely) fix */
+  primary: boolean;
+  /** Optional command to run */
+  command?: string;
+}
+
+/**
+ * Error definition in the registry.
+ */
+export interface ErrorDefinition {
+  /** Exit code for this error (1-6) */
+  exitCode: number;
+  /** Error category */
+  category: ErrorCategory;
+  /** Human-readable message template */
+  template: string;
+  /** URL to documentation for this error */
+  docs: string;
+  /** Default suggestions (can be overridden per-instance) */
+  defaultSuggestions: Suggestion[];
+}
+
+/**
+ * Context about the command that triggered the error.
+ * Used to generate context-aware error messages.
+ */
+export interface ErrorContext {
+  /** Command being executed (e.g., 'dispatch complete') */
+  command?: string;
+  /** Flags passed to the command */
+  flags?: string[];
+  /** Flag that was missing (for validation errors) */
+  missingFlag?: string;
+  /** Current working directory */
+  workingDir?: string;
+  /** Whether this is a git repository */
+  hasGit?: boolean;
+  /** Whether ADA is initialized in this directory */
+  hasAda?: boolean;
+}
+
+/**
+ * Structured error data for JSON output.
+ */
+export interface ErrorJson {
+  ok: false;
+  error: {
+    code: ErrorCode;
+    message: string;
+    details: Record<string, unknown>;
+    suggestions: Suggestion[];
+    docs: string;
+    exitCode: number;
+  };
+}
+
+/**
+ * Rendering options for error output.
+ */
+export interface RenderOptions {
+  /** Whether to output JSON format */
+  json?: boolean;
+  /** Whether output is to a TTY (terminal) */
+  tty?: boolean;
+  /** Whether to use colors (respects NO_COLOR env) */
+  color?: boolean;
+  /** Whether running in CI environment */
+  ci?: boolean;
+}
+
+/**
+ * Standard exit codes per C1082 spec.
+ */
+export const EXIT_CODES = {
+  SUCCESS: 0,
+  GENERAL_ERROR: 1,
+  USAGE_ERROR: 2,
+  CONFIG_ERROR: 3,
+  RUNTIME_ERROR: 4,
+  NETWORK_ERROR: 5,
+  GIT_ERROR: 6,
+} as const;
+
+/**
+ * Category to exit code mapping.
+ */
+export const CATEGORY_EXIT_CODES: Record<ErrorCategory, number> = {
+  config: EXIT_CODES.CONFIG_ERROR,
+  runtime: EXIT_CODES.RUNTIME_ERROR,
+  network: EXIT_CODES.NETWORK_ERROR,
+  validation: EXIT_CODES.USAGE_ERROR,
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -696,3 +696,33 @@ export {
   createInnateLoader,
   DEFAULT_INNATE_FILES,
 } from './memory/index.js';
+
+// Error Handling (Issue #185 — Better Error Messages, Design Spec C1082)
+// Structured errors with actionable suggestions, error codes, and exit codes.
+// Implements ErrorBuilder pattern, TTY/plain/JSON rendering.
+export type {
+  ErrorCategory,
+  ErrorCode,
+  Suggestion,
+  ErrorDefinition,
+  ErrorContext,
+  ErrorJson,
+  RenderOptions,
+} from './errors/index.js';
+export {
+  EXIT_CODES,
+  CATEGORY_EXIT_CODES,
+  ERROR_REGISTRY,
+  DOCS_BASE_URL,
+  getErrorDefinition,
+  isValidErrorCode,
+  AdaError,
+  ErrorBuilder,
+  adaError,
+  shouldUseColors,
+  shouldUseJson,
+  detectRenderOptions,
+  renderError,
+  printError,
+  withErrorHandler,
+} from './errors/index.js';

--- a/packages/core/tests/errors/builder.test.ts
+++ b/packages/core/tests/errors/builder.test.ts
@@ -1,0 +1,281 @@
+/**
+ * @file Tests for ErrorBuilder fluent API
+ * @description Tests the fluent builder pattern for constructing AdaError instances
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ErrorBuilder, adaError } from '../../src/errors/builder.js';
+import { AdaError } from '../../src/errors/error.js';
+
+describe('ErrorBuilder', () => {
+  describe('basic construction', () => {
+    it('builds AdaError with just code', () => {
+      const error = new ErrorBuilder('ADA_NOT_INITIALIZED').build();
+
+      expect(error).toBeInstanceOf(AdaError);
+      expect(error.code).toBe('ADA_NOT_INITIALIZED');
+    });
+  });
+
+  describe('message', () => {
+    it('overrides default message', () => {
+      const error = new ErrorBuilder('ADA_NOT_INITIALIZED')
+        .message('Custom error message')
+        .build();
+
+      expect(error.message).toBe('Custom error message');
+    });
+  });
+
+  describe('context methods', () => {
+    it('sets command context', () => {
+      const error = new ErrorBuilder('ADA_MISSING_ACTION')
+        .context('dispatch complete')
+        .build();
+
+      expect(error.context?.command).toBe('dispatch complete');
+    });
+
+    it('sets working directory', () => {
+      const error = new ErrorBuilder('ADA_NOT_INITIALIZED')
+        .workDir('/home/user/project')
+        .build();
+
+      expect(error.context?.workingDir).toBe('/home/user/project');
+    });
+
+    it('sets flags', () => {
+      const error = new ErrorBuilder('ADA_MISSING_ACTION')
+        .flags(['--reflection', '--verbose'])
+        .build();
+
+      expect(error.context?.flags).toEqual(['--reflection', '--verbose']);
+    });
+
+    it('sets missing flag', () => {
+      const error = new ErrorBuilder('ADA_MISSING_ACTION')
+        .missingFlag('--action')
+        .build();
+
+      expect(error.context?.missingFlag).toBe('--action');
+    });
+
+    it('sets git status', () => {
+      const error = new ErrorBuilder('ADA_NOT_INITIALIZED')
+        .git(true)
+        .build();
+
+      expect(error.context?.hasGit).toBe(true);
+    });
+
+    it('sets ada status', () => {
+      const error = new ErrorBuilder('ADA_NOT_INITIALIZED')
+        .ada(false)
+        .build();
+
+      expect(error.context?.hasAda).toBe(false);
+    });
+
+    it('combines multiple context values', () => {
+      const error = new ErrorBuilder('ADA_MISSING_ACTION')
+        .context('dispatch complete')
+        .workDir('/home/user/project')
+        .flags(['--reflection'])
+        .missingFlag('--action')
+        .git(true)
+        .ada(true)
+        .build();
+
+      expect(error.context).toEqual({
+        command: 'dispatch complete',
+        workingDir: '/home/user/project',
+        flags: ['--reflection'],
+        missingFlag: '--action',
+        hasGit: true,
+        hasAda: true,
+      });
+    });
+  });
+
+  describe('detail methods', () => {
+    it('adds single detail', () => {
+      const error = new ErrorBuilder('ADA_NOT_INITIALIZED')
+        .detail('missingFile', 'rotation.json')
+        .build();
+
+      expect(error.details).toEqual({ missingFile: 'rotation.json' });
+    });
+
+    it('adds multiple details with detail()', () => {
+      const error = new ErrorBuilder('ADA_NOT_INITIALIZED')
+        .detail('missingFile', 'rotation.json')
+        .detail('expectedPath', 'agents/state/')
+        .build();
+
+      expect(error.details).toEqual({
+        missingFile: 'rotation.json',
+        expectedPath: 'agents/state/',
+      });
+    });
+
+    it('adds multiple details with details()', () => {
+      const error = new ErrorBuilder('ADA_NOT_INITIALIZED')
+        .details({
+          missingFile: 'rotation.json',
+          expectedPath: 'agents/state/',
+        })
+        .build();
+
+      expect(error.details).toEqual({
+        missingFile: 'rotation.json',
+        expectedPath: 'agents/state/',
+      });
+    });
+
+    it('merges details from both methods', () => {
+      const error = new ErrorBuilder('ADA_NOT_INITIALIZED')
+        .detail('first', '1')
+        .details({ second: '2', third: '3' })
+        .detail('fourth', '4')
+        .build();
+
+      expect(error.details).toEqual({
+        first: '1',
+        second: '2',
+        third: '3',
+        fourth: '4',
+      });
+    });
+  });
+
+  describe('suggestion methods', () => {
+    it('adds suggestion without options', () => {
+      const error = new ErrorBuilder('ADA_NOT_INITIALIZED')
+        .suggest('Try this fix')
+        .build();
+
+      const customSuggestion = error.suggestions.find(
+        (s) => s.action === 'Try this fix'
+      );
+      expect(customSuggestion).toBeDefined();
+      expect(customSuggestion?.primary).toBe(false);
+    });
+
+    it('adds primary suggestion', () => {
+      const error = new ErrorBuilder('ADA_NOT_INITIALIZED')
+        .suggest('Primary fix', { primary: true })
+        .build();
+
+      const customSuggestion = error.suggestions.find(
+        (s) => s.action === 'Primary fix'
+      );
+      expect(customSuggestion?.primary).toBe(true);
+    });
+
+    it('adds suggestion with command', () => {
+      const error = new ErrorBuilder('ADA_NOT_INITIALIZED')
+        .suggest('Run initialization', { command: 'ada init' })
+        .build();
+
+      const customSuggestion = error.suggestions.find(
+        (s) => s.action === 'Run initialization'
+      );
+      expect(customSuggestion?.command).toBe('ada init');
+    });
+
+    it('suggestPrimary adds primary suggestion with command', () => {
+      const error = new ErrorBuilder('ADA_NOT_INITIALIZED')
+        .suggestPrimary('Initialize now', 'ada init')
+        .build();
+
+      const customSuggestion = error.suggestions.find(
+        (s) => s.action === 'Initialize now'
+      );
+      expect(customSuggestion?.primary).toBe(true);
+      expect(customSuggestion?.command).toBe('ada init');
+    });
+
+    it('replaceSuggestions removes defaults', () => {
+      const error = new ErrorBuilder('ADA_NOT_INITIALIZED')
+        .replaceSuggestions()
+        .suggest('Only this', { primary: true })
+        .build();
+
+      expect(error.suggestions).toHaveLength(1);
+      expect(error.suggestions[0].action).toBe('Only this');
+    });
+  });
+
+  describe('cause', () => {
+    it('sets cause error', () => {
+      const original = new Error('Original failure');
+      const error = new ErrorBuilder('ADA_UNKNOWN_ERROR')
+        .cause(original)
+        .build();
+
+      expect(error.cause).toBe(original);
+    });
+  });
+
+  describe('throw', () => {
+    it('throws the built error', () => {
+      expect(() => {
+        new ErrorBuilder('ADA_NOT_INITIALIZED').throw();
+      }).toThrow(AdaError);
+    });
+
+    it('thrown error has correct code', () => {
+      try {
+        new ErrorBuilder('ADA_NOT_INITIALIZED')
+          .detail('test', 'value')
+          .throw();
+      } catch (error) {
+        expect(AdaError.isAdaError(error)).toBe(true);
+        if (AdaError.isAdaError(error)) {
+          expect(error.code).toBe('ADA_NOT_INITIALIZED');
+          expect(error.details).toEqual({ test: 'value' });
+        }
+      }
+    });
+  });
+
+  describe('full chain', () => {
+    it('supports full fluent chain', () => {
+      const error = new ErrorBuilder('ADA_MISSING_ACTION')
+        .message('Missing required action flag')
+        .context('dispatch complete')
+        .workDir('/home/user/project')
+        .flags(['--reflection'])
+        .missingFlag('--action')
+        .git(true)
+        .ada(true)
+        .detail('expectedFlag', '--action')
+        .detail('receivedFlags', ['--reflection'])
+        .suggestPrimary('Add the --action flag', 'ada dispatch complete --action "..."')
+        .suggest('See help for more options', { command: 'ada dispatch complete --help' })
+        .build();
+
+      expect(error.code).toBe('ADA_MISSING_ACTION');
+      expect(error.message).toBe('Missing required action flag');
+      expect(error.context?.command).toBe('dispatch complete');
+      expect(error.context?.missingFlag).toBe('--action');
+      expect(error.details.expectedFlag).toBe('--action');
+    });
+  });
+});
+
+describe('adaError factory', () => {
+  it('creates ErrorBuilder', () => {
+    const builder = adaError('ADA_NOT_INITIALIZED');
+    expect(builder).toBeInstanceOf(ErrorBuilder);
+  });
+
+  it('can build error', () => {
+    const error = adaError('ADA_NOT_INITIALIZED')
+      .detail('test', 'value')
+      .build();
+
+    expect(error).toBeInstanceOf(AdaError);
+    expect(error.code).toBe('ADA_NOT_INITIALIZED');
+  });
+});

--- a/packages/core/tests/errors/error.test.ts
+++ b/packages/core/tests/errors/error.test.ts
@@ -1,0 +1,253 @@
+/**
+ * @file Tests for AdaError class
+ * @description Tests error construction, JSON serialization, and error wrapping
+ */
+
+import { describe, it, expect } from 'vitest';
+import { AdaError } from '../../src/errors/error.js';
+
+describe('AdaError', () => {
+  describe('constructor', () => {
+    it('creates error with default message from registry', () => {
+      const error = new AdaError('ADA_NOT_INITIALIZED');
+
+      expect(error.code).toBe('ADA_NOT_INITIALIZED');
+      expect(error.message).toBe(
+        "This directory doesn't have an ADA agent team configured"
+      );
+      expect(error.category).toBe('config');
+      expect(error.exitCode).toBe(3);
+      expect(error.docs).toContain('ADA_NOT_INITIALIZED');
+    });
+
+    it('allows message override', () => {
+      const error = new AdaError('ADA_NOT_INITIALIZED', {
+        message: 'Custom message here',
+      });
+
+      expect(error.message).toBe('Custom message here');
+      expect(error.code).toBe('ADA_NOT_INITIALIZED');
+    });
+
+    it('includes details', () => {
+      const error = new AdaError('ADA_NOT_INITIALIZED', {
+        details: {
+          missingFile: 'rotation.json',
+          workingDir: '/home/user/project',
+        },
+      });
+
+      expect(error.details).toEqual({
+        missingFile: 'rotation.json',
+        workingDir: '/home/user/project',
+      });
+    });
+
+    it('includes context', () => {
+      const error = new AdaError('ADA_MISSING_ACTION', {
+        context: {
+          command: 'dispatch complete',
+          flags: ['--reflection'],
+          missingFlag: '--action',
+        },
+      });
+
+      expect(error.context).toEqual({
+        command: 'dispatch complete',
+        flags: ['--reflection'],
+        missingFlag: '--action',
+      });
+    });
+
+    it('merges custom suggestions with defaults', () => {
+      const error = new AdaError('ADA_NOT_INITIALIZED', {
+        suggestions: [
+          { action: 'Check parent directories', primary: false },
+        ],
+      });
+
+      // Should have default suggestions plus custom one
+      expect(error.suggestions.length).toBeGreaterThan(1);
+      expect(error.suggestions.some((s) => s.action.includes('ada init'))).toBe(
+        true
+      );
+      expect(
+        error.suggestions.some((s) => s.action.includes('parent directories'))
+      ).toBe(true);
+    });
+
+    it('replaces suggestions when replaceSuggestions is true', () => {
+      const error = new AdaError('ADA_NOT_INITIALIZED', {
+        suggestions: [{ action: 'Only this suggestion', primary: true }],
+        replaceSuggestions: true,
+      });
+
+      expect(error.suggestions).toHaveLength(1);
+      expect(error.suggestions[0].action).toBe('Only this suggestion');
+    });
+
+    it('preserves cause error', () => {
+      const cause = new Error('Original error');
+      const error = new AdaError('ADA_UNKNOWN_ERROR', {
+        cause,
+      });
+
+      expect(error.cause).toBe(cause);
+    });
+  });
+
+  describe('primarySuggestion', () => {
+    it('returns the first primary suggestion', () => {
+      const error = new AdaError('ADA_NOT_INITIALIZED');
+      const primary = error.primarySuggestion;
+
+      expect(primary).toBeDefined();
+      expect(primary?.primary).toBe(true);
+      expect(primary?.action).toContain('ada init');
+    });
+
+    it('returns undefined when no primary suggestion', () => {
+      const error = new AdaError('ADA_UNKNOWN_ERROR', {
+        suggestions: [
+          { action: 'Not primary', primary: false },
+        ],
+        replaceSuggestions: true,
+      });
+
+      expect(error.primarySuggestion).toBeUndefined();
+    });
+  });
+
+  describe('secondarySuggestions', () => {
+    it('returns non-primary suggestions', () => {
+      const error = new AdaError('ADA_NOT_INITIALIZED');
+      const secondary = error.secondarySuggestions;
+
+      expect(secondary.every((s) => !s.primary)).toBe(true);
+    });
+  });
+
+  describe('toJSON', () => {
+    it('serializes to structured JSON format', () => {
+      const error = new AdaError('ADA_NOT_INITIALIZED', {
+        details: { missingFile: 'rotation.json' },
+        context: { command: 'dispatch start' },
+      });
+
+      const json = error.toJSON();
+
+      expect(json.ok).toBe(false);
+      expect(json.error.code).toBe('ADA_NOT_INITIALIZED');
+      expect(json.error.message).toBe(
+        "This directory doesn't have an ADA agent team configured"
+      );
+      expect(json.error.details).toEqual({ missingFile: 'rotation.json' });
+      expect(json.error.suggestions).toBeInstanceOf(Array);
+      expect(json.error.docs).toContain('ADA_NOT_INITIALIZED');
+      expect(json.error.exitCode).toBe(3);
+      expect(json.error.context).toEqual({ command: 'dispatch start' });
+    });
+
+    it('omits context when not provided', () => {
+      const error = new AdaError('ADA_NOT_INITIALIZED');
+      const json = error.toJSON();
+
+      expect(json.error.context).toBeUndefined();
+    });
+  });
+
+  describe('from', () => {
+    it('returns AdaError unchanged', () => {
+      const original = new AdaError('ADA_NOT_INITIALIZED');
+      const result = AdaError.from(original);
+
+      expect(result).toBe(original);
+    });
+
+    it('wraps Error with ADA_UNKNOWN_ERROR', () => {
+      const error = new Error('Something went wrong');
+      const result = AdaError.from(error);
+
+      expect(result.code).toBe('ADA_UNKNOWN_ERROR');
+      expect(result.message).toBe('Something went wrong');
+      expect(result.cause).toBe(error);
+    });
+
+    it('wraps string with ADA_UNKNOWN_ERROR', () => {
+      const result = AdaError.from('String error');
+
+      expect(result.code).toBe('ADA_UNKNOWN_ERROR');
+      expect(result.message).toBe('String error');
+    });
+
+    it('uses fallbackCode when provided', () => {
+      const error = new Error('Network issue');
+      const result = AdaError.from(error, {
+        fallbackCode: 'ADA_NETWORK_OFFLINE',
+      });
+
+      expect(result.code).toBe('ADA_NETWORK_OFFLINE');
+      expect(result.message).toBe('Network issue');
+    });
+
+    it('includes context when provided', () => {
+      const error = new Error('Something failed');
+      const result = AdaError.from(error, {
+        context: { command: 'dispatch complete' },
+      });
+
+      expect(result.context).toEqual({ command: 'dispatch complete' });
+    });
+  });
+
+  describe('isAdaError', () => {
+    it('returns true for AdaError', () => {
+      const error = new AdaError('ADA_NOT_INITIALIZED');
+      expect(AdaError.isAdaError(error)).toBe(true);
+    });
+
+    it('returns false for regular Error', () => {
+      const error = new Error('Regular error');
+      expect(AdaError.isAdaError(error)).toBe(false);
+    });
+
+    it('returns false for non-errors', () => {
+      expect(AdaError.isAdaError('string')).toBe(false);
+      expect(AdaError.isAdaError(null)).toBe(false);
+      expect(AdaError.isAdaError(undefined)).toBe(false);
+      expect(AdaError.isAdaError({})).toBe(false);
+    });
+  });
+
+  describe('exit codes', () => {
+    it('config errors have exit code 3', () => {
+      expect(new AdaError('ADA_NOT_INITIALIZED').exitCode).toBe(3);
+      expect(new AdaError('ADA_INVALID_CONFIG').exitCode).toBe(3);
+      expect(new AdaError('ADA_MISSING_PLAYBOOK').exitCode).toBe(3);
+      expect(new AdaError('ADA_CORRUPT_STATE').exitCode).toBe(3);
+    });
+
+    it('runtime errors have exit code 4', () => {
+      expect(new AdaError('ADA_CYCLE_IN_PROGRESS').exitCode).toBe(4);
+      expect(new AdaError('ADA_WRONG_ROLE').exitCode).toBe(4);
+    });
+
+    it('network errors have exit code 5', () => {
+      expect(new AdaError('ADA_GITHUB_UNAUTHORIZED').exitCode).toBe(5);
+      expect(new AdaError('ADA_GITHUB_RATE_LIMIT').exitCode).toBe(5);
+      expect(new AdaError('ADA_GITHUB_NOT_FOUND').exitCode).toBe(5);
+      expect(new AdaError('ADA_NETWORK_OFFLINE').exitCode).toBe(5);
+    });
+
+    it('validation errors have exit code 2', () => {
+      expect(new AdaError('ADA_MISSING_ACTION').exitCode).toBe(2);
+      expect(new AdaError('ADA_INVALID_ROLE').exitCode).toBe(2);
+      expect(new AdaError('ADA_EMPTY_MEMORY').exitCode).toBe(2);
+    });
+
+    it('git errors have exit code 6', () => {
+      expect(new AdaError('ADA_GIT_DIRTY').exitCode).toBe(6);
+      expect(new AdaError('ADA_GIT_CONFLICT').exitCode).toBe(6);
+    });
+  });
+});

--- a/packages/core/tests/errors/registry.test.ts
+++ b/packages/core/tests/errors/registry.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @file Tests for error registry
+ * @description Tests error code registry and definitions
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ERROR_REGISTRY,
+  DOCS_BASE_URL,
+  getErrorDefinition,
+  isValidErrorCode,
+} from '../../src/errors/registry.js';
+import { EXIT_CODES } from '../../src/errors/types.js';
+
+describe('ERROR_REGISTRY', () => {
+  it('contains all documented error codes', () => {
+    const expectedCodes = [
+      // Config errors
+      'ADA_NOT_INITIALIZED',
+      'ADA_INVALID_CONFIG',
+      'ADA_MISSING_PLAYBOOK',
+      'ADA_CORRUPT_STATE',
+      // Runtime errors
+      'ADA_CYCLE_IN_PROGRESS',
+      'ADA_WRONG_ROLE',
+      'ADA_GIT_DIRTY',
+      'ADA_GIT_CONFLICT',
+      // Network errors
+      'ADA_GITHUB_UNAUTHORIZED',
+      'ADA_GITHUB_RATE_LIMIT',
+      'ADA_GITHUB_NOT_FOUND',
+      'ADA_NETWORK_OFFLINE',
+      // Validation errors
+      'ADA_MISSING_ACTION',
+      'ADA_INVALID_ROLE',
+      'ADA_EMPTY_MEMORY',
+      // Generic
+      'ADA_UNKNOWN_ERROR',
+    ];
+
+    for (const code of expectedCodes) {
+      expect(ERROR_REGISTRY[code as keyof typeof ERROR_REGISTRY]).toBeDefined();
+    }
+  });
+
+  it('all entries have required fields', () => {
+    for (const [, definition] of Object.entries(ERROR_REGISTRY)) {
+      expect(definition.exitCode).toBeTypeOf('number');
+      expect(definition.category).toBeTypeOf('string');
+      expect(definition.template).toBeTypeOf('string');
+      expect(definition.docs).toBeTypeOf('string');
+      expect(definition.defaultSuggestions).toBeInstanceOf(Array);
+      expect(definition.defaultSuggestions.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('all entries have at least one primary suggestion', () => {
+    for (const [, definition] of Object.entries(ERROR_REGISTRY)) {
+      const hasPrimary = definition.defaultSuggestions.some((s) => s.primary);
+      expect(hasPrimary).toBe(true);
+    }
+  });
+
+  it('all docs URLs use DOCS_BASE_URL', () => {
+    for (const [code, definition] of Object.entries(ERROR_REGISTRY)) {
+      expect(definition.docs).toContain(DOCS_BASE_URL);
+      expect(definition.docs).toContain(code);
+    }
+  });
+
+  describe('exit codes', () => {
+    it('config errors have exit code 3', () => {
+      expect(ERROR_REGISTRY.ADA_NOT_INITIALIZED.exitCode).toBe(EXIT_CODES.CONFIG_ERROR);
+      expect(ERROR_REGISTRY.ADA_INVALID_CONFIG.exitCode).toBe(EXIT_CODES.CONFIG_ERROR);
+      expect(ERROR_REGISTRY.ADA_MISSING_PLAYBOOK.exitCode).toBe(EXIT_CODES.CONFIG_ERROR);
+      expect(ERROR_REGISTRY.ADA_CORRUPT_STATE.exitCode).toBe(EXIT_CODES.CONFIG_ERROR);
+    });
+
+    it('runtime errors have exit code 4', () => {
+      expect(ERROR_REGISTRY.ADA_CYCLE_IN_PROGRESS.exitCode).toBe(EXIT_CODES.RUNTIME_ERROR);
+      expect(ERROR_REGISTRY.ADA_WRONG_ROLE.exitCode).toBe(EXIT_CODES.RUNTIME_ERROR);
+    });
+
+    it('network errors have exit code 5', () => {
+      expect(ERROR_REGISTRY.ADA_GITHUB_UNAUTHORIZED.exitCode).toBe(EXIT_CODES.NETWORK_ERROR);
+      expect(ERROR_REGISTRY.ADA_GITHUB_RATE_LIMIT.exitCode).toBe(EXIT_CODES.NETWORK_ERROR);
+      expect(ERROR_REGISTRY.ADA_GITHUB_NOT_FOUND.exitCode).toBe(EXIT_CODES.NETWORK_ERROR);
+      expect(ERROR_REGISTRY.ADA_NETWORK_OFFLINE.exitCode).toBe(EXIT_CODES.NETWORK_ERROR);
+    });
+
+    it('validation errors have exit code 2', () => {
+      expect(ERROR_REGISTRY.ADA_MISSING_ACTION.exitCode).toBe(EXIT_CODES.USAGE_ERROR);
+      expect(ERROR_REGISTRY.ADA_INVALID_ROLE.exitCode).toBe(EXIT_CODES.USAGE_ERROR);
+      expect(ERROR_REGISTRY.ADA_EMPTY_MEMORY.exitCode).toBe(EXIT_CODES.USAGE_ERROR);
+    });
+
+    it('git errors have exit code 6', () => {
+      expect(ERROR_REGISTRY.ADA_GIT_DIRTY.exitCode).toBe(EXIT_CODES.GIT_ERROR);
+      expect(ERROR_REGISTRY.ADA_GIT_CONFLICT.exitCode).toBe(EXIT_CODES.GIT_ERROR);
+    });
+  });
+
+  describe('categories', () => {
+    it('config errors have config category', () => {
+      expect(ERROR_REGISTRY.ADA_NOT_INITIALIZED.category).toBe('config');
+      expect(ERROR_REGISTRY.ADA_INVALID_CONFIG.category).toBe('config');
+    });
+
+    it('runtime errors have runtime category', () => {
+      expect(ERROR_REGISTRY.ADA_CYCLE_IN_PROGRESS.category).toBe('runtime');
+      expect(ERROR_REGISTRY.ADA_WRONG_ROLE.category).toBe('runtime');
+    });
+
+    it('network errors have network category', () => {
+      expect(ERROR_REGISTRY.ADA_GITHUB_UNAUTHORIZED.category).toBe('network');
+      expect(ERROR_REGISTRY.ADA_NETWORK_OFFLINE.category).toBe('network');
+    });
+
+    it('validation errors have validation category', () => {
+      expect(ERROR_REGISTRY.ADA_MISSING_ACTION.category).toBe('validation');
+      expect(ERROR_REGISTRY.ADA_INVALID_ROLE.category).toBe('validation');
+    });
+  });
+});
+
+describe('getErrorDefinition', () => {
+  it('returns definition for valid code', () => {
+    const definition = getErrorDefinition('ADA_NOT_INITIALIZED');
+
+    expect(definition.category).toBe('config');
+    expect(definition.exitCode).toBe(3);
+    expect(definition.template).toContain('ADA agent team');
+  });
+
+  it('returns unknown error for invalid code', () => {
+    // @ts-expect-error Testing invalid code
+    const definition = getErrorDefinition('INVALID_CODE');
+
+    expect(definition.exitCode).toBe(EXIT_CODES.GENERAL_ERROR);
+    expect(definition).toBe(ERROR_REGISTRY.ADA_UNKNOWN_ERROR);
+  });
+});
+
+describe('isValidErrorCode', () => {
+  it('returns true for valid codes', () => {
+    expect(isValidErrorCode('ADA_NOT_INITIALIZED')).toBe(true);
+    expect(isValidErrorCode('ADA_GITHUB_UNAUTHORIZED')).toBe(true);
+    expect(isValidErrorCode('ADA_MISSING_ACTION')).toBe(true);
+  });
+
+  it('returns false for invalid codes', () => {
+    expect(isValidErrorCode('INVALID_CODE')).toBe(false);
+    expect(isValidErrorCode('')).toBe(false);
+    expect(isValidErrorCode('ADA_FAKE_ERROR')).toBe(false);
+  });
+});
+
+describe('DOCS_BASE_URL', () => {
+  it('is a valid URL', () => {
+    expect(DOCS_BASE_URL).toMatch(/^https?:\/\//);
+  });
+
+  it('ends with /errors', () => {
+    expect(DOCS_BASE_URL).toMatch(/\/errors$/);
+  });
+});

--- a/packages/core/tests/errors/renderer.test.ts
+++ b/packages/core/tests/errors/renderer.test.ts
@@ -1,0 +1,310 @@
+/**
+ * @file Tests for error rendering
+ * @description Tests TTY, plain, and JSON error output formatting
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  shouldUseColors,
+  shouldUseJson,
+  detectRenderOptions,
+  renderError,
+} from '../../src/errors/renderer.js';
+import { AdaError } from '../../src/errors/error.js';
+
+describe('shouldUseColors', () => {
+  const originalEnv = { ...process.env };
+  const originalIsTTY = process.stdout.isTTY;
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: originalIsTTY,
+      writable: true,
+    });
+  });
+
+  it('returns false when NO_COLOR is set', () => {
+    process.env.NO_COLOR = '1';
+    expect(shouldUseColors()).toBe(false);
+  });
+
+  it('returns true when FORCE_COLOR is set', () => {
+    delete process.env.NO_COLOR;
+    process.env.FORCE_COLOR = '1';
+    expect(shouldUseColors()).toBe(true);
+  });
+
+  it('returns false in CI environment', () => {
+    delete process.env.NO_COLOR;
+    delete process.env.FORCE_COLOR;
+    process.env.CI = 'true';
+    expect(shouldUseColors()).toBe(false);
+  });
+
+  it('returns true for TTY when no env vars set', () => {
+    delete process.env.NO_COLOR;
+    delete process.env.FORCE_COLOR;
+    delete process.env.CI;
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      writable: true,
+    });
+    expect(shouldUseColors()).toBe(true);
+  });
+
+  it('returns false for non-TTY when no env vars set', () => {
+    delete process.env.NO_COLOR;
+    delete process.env.FORCE_COLOR;
+    delete process.env.CI;
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: false,
+      writable: true,
+    });
+    expect(shouldUseColors()).toBe(false);
+  });
+});
+
+describe('shouldUseJson', () => {
+  const originalEnv = { ...process.env };
+  const originalArgv = [...process.argv];
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    process.argv = [...originalArgv];
+  });
+
+  it('returns true when ADA_OUTPUT=json', () => {
+    process.env.ADA_OUTPUT = 'json';
+    expect(shouldUseJson()).toBe(true);
+  });
+
+  it('returns true when --json flag present', () => {
+    process.env.ADA_OUTPUT = '';
+    process.argv = ['node', 'ada', '--json'];
+    expect(shouldUseJson()).toBe(true);
+  });
+
+  it('returns true when -j flag present', () => {
+    process.env.ADA_OUTPUT = '';
+    process.argv = ['node', 'ada', '-j'];
+    expect(shouldUseJson()).toBe(true);
+  });
+
+  it('returns false when no json indicators', () => {
+    delete process.env.ADA_OUTPUT;
+    process.argv = ['node', 'ada', 'dispatch', 'start'];
+    expect(shouldUseJson()).toBe(false);
+  });
+});
+
+describe('detectRenderOptions', () => {
+  const originalEnv = { ...process.env };
+  const originalArgv = [...process.argv];
+
+  beforeEach(() => {
+    delete process.env.NO_COLOR;
+    delete process.env.FORCE_COLOR;
+    delete process.env.CI;
+    delete process.env.ADA_OUTPUT;
+    process.argv = ['node', 'ada'];
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    process.argv = [...originalArgv];
+  });
+
+  it('detects JSON mode', () => {
+    process.env.ADA_OUTPUT = 'json';
+    const options = detectRenderOptions();
+    expect(options.json).toBe(true);
+  });
+
+  it('detects CI environment', () => {
+    process.env.CI = 'true';
+    const options = detectRenderOptions();
+    expect(options.ci).toBe(true);
+  });
+});
+
+describe('renderError', () => {
+  const error = new AdaError('ADA_NOT_INITIALIZED', {
+    details: { missingFile: 'rotation.json' },
+    context: { command: 'dispatch start' },
+  });
+
+  describe('JSON output', () => {
+    it('renders valid JSON', () => {
+      const output = renderError(error, { json: true });
+      const parsed = JSON.parse(output);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error.code).toBe('ADA_NOT_INITIALIZED');
+      expect(parsed.error.message).toBe(
+        "This directory doesn't have an ADA agent team configured"
+      );
+      expect(parsed.error.details).toEqual({ missingFile: 'rotation.json' });
+      expect(parsed.error.exitCode).toBe(3);
+    });
+
+    it('includes suggestions in JSON', () => {
+      const output = renderError(error, { json: true });
+      const parsed = JSON.parse(output);
+
+      expect(parsed.error.suggestions).toBeInstanceOf(Array);
+      expect(parsed.error.suggestions.length).toBeGreaterThan(0);
+    });
+
+    it('includes docs link in JSON', () => {
+      const output = renderError(error, { json: true });
+      const parsed = JSON.parse(output);
+
+      expect(parsed.error.docs).toContain('ADA_NOT_INITIALIZED');
+    });
+  });
+
+  describe('plain text output', () => {
+    it('includes error code in header', () => {
+      const output = renderError(error, { tty: false, color: false });
+
+      expect(output).toContain('ERROR');
+      expect(output).toContain('ADA_NOT_INITIALIZED');
+    });
+
+    it('includes message', () => {
+      const output = renderError(error, { tty: false, color: false });
+
+      expect(output).toContain(
+        "This directory doesn't have an ADA agent team configured"
+      );
+    });
+
+    it('includes details', () => {
+      const output = renderError(error, { tty: false, color: false });
+
+      expect(output).toContain('missingFile');
+      expect(output).toContain('rotation.json');
+    });
+
+    it('includes fix suggestion', () => {
+      const output = renderError(error, { tty: false, color: false });
+
+      expect(output).toContain('Fix:');
+      expect(output).toContain('ada init');
+    });
+
+    it('includes docs link', () => {
+      const output = renderError(error, { tty: false, color: false });
+
+      expect(output).toContain('Docs:');
+      expect(output).toContain('ADA_NOT_INITIALIZED');
+    });
+  });
+
+  describe('TTY output', () => {
+    it('includes error symbol when color enabled (full TTY)', () => {
+      const output = renderError(error, { tty: true, color: true });
+
+      expect(output).toContain('✖');
+    });
+
+    it('includes error code in parentheses when color enabled', () => {
+      const output = renderError(error, { tty: true, color: true });
+
+      expect(output).toContain('(ADA_NOT_INITIALIZED)');
+    });
+
+    it('includes suggestion emoji when color enabled', () => {
+      const output = renderError(error, { tty: true, color: true });
+
+      expect(output).toContain('💡');
+    });
+
+    it('includes docs emoji when color enabled', () => {
+      const output = renderError(error, { tty: true, color: true });
+
+      expect(output).toContain('📖');
+    });
+
+    it('formats suggestions with arrows for secondary when color enabled', () => {
+      const output = renderError(error, { tty: true, color: true });
+
+      expect(output).toContain('→');
+    });
+
+    it('falls back to plain format when color disabled', () => {
+      const output = renderError(error, { tty: true, color: false });
+
+      expect(output).toContain('ERROR');
+      expect(output).toContain('[ADA_NOT_INITIALIZED]');
+    });
+  });
+
+  describe('colored output', () => {
+    it('includes ANSI codes when color enabled', () => {
+      const output = renderError(error, { tty: true, color: true });
+
+      // Should contain ANSI escape codes (ESC [ digit m pattern)
+      // eslint-disable-next-line no-control-regex
+      expect(output).toMatch(/\x1b\[\d+m/);
+    });
+
+    it('no ANSI codes when color disabled', () => {
+      const output = renderError(error, { tty: true, color: false });
+
+      // Should not contain ANSI escape codes
+      // eslint-disable-next-line no-control-regex
+      expect(output).not.toMatch(/\x1b\[\d+m/);
+    });
+  });
+});
+
+describe('error rendering for different error types', () => {
+  it('renders config errors', () => {
+    const error = new AdaError('ADA_CORRUPT_STATE');
+    const output = renderError(error, { json: true });
+    const parsed = JSON.parse(output);
+
+    expect(parsed.error.exitCode).toBe(3);
+    expect(parsed.error.code).toBe('ADA_CORRUPT_STATE');
+  });
+
+  it('renders network errors', () => {
+    const error = new AdaError('ADA_GITHUB_UNAUTHORIZED');
+    const output = renderError(error, { json: true });
+    const parsed = JSON.parse(output);
+
+    expect(parsed.error.exitCode).toBe(5);
+    // Check that there's a suggestion with gh auth login command
+    expect(parsed.error.suggestions).toContainEqual(
+      expect.objectContaining({
+        command: 'gh auth login',
+      })
+    );
+  });
+
+  it('renders validation errors', () => {
+    const error = new AdaError('ADA_MISSING_ACTION', {
+      context: { command: 'dispatch complete' },
+    });
+    const output = renderError(error, { json: true });
+    const parsed = JSON.parse(output);
+
+    expect(parsed.error.exitCode).toBe(2);
+    expect(parsed.error.context.command).toBe('dispatch complete');
+  });
+
+  it('renders git errors', () => {
+    const error = new AdaError('ADA_GIT_DIRTY', {
+      details: {
+        files: ['agents/memory/bank.md', 'docs/new-feature.md'],
+      },
+    });
+    const output = renderError(error, { json: true });
+    const parsed = JSON.parse(output);
+
+    expect(parsed.error.exitCode).toBe(6);
+    expect(parsed.error.details.files).toContain('agents/memory/bank.md');
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phase 1 of #185 per `docs/design/cli-error-messages-ux-spec-c1082.md`.

## Type of Change
- feat (new feature)

## Related Issues
- Relates to #185

## Changes Made

### New Error Module (`@ada-ai/core`)

- **AdaError class** (`src/errors/error.ts`)
  - Structured error with code, message, details, suggestions, docs link, exit code
  - `toJSON()` for structured output
  - `AdaError.from()` to wrap unknown errors
  - `AdaError.isAdaError()` type guard

- **Error Registry** (`src/errors/registry.ts`)
  - 16 standardized error codes across 4 categories:
    - Config: `ADA_NOT_INITIALIZED`, `ADA_INVALID_CONFIG`, `ADA_MISSING_PLAYBOOK`, `ADA_CORRUPT_STATE`
    - Runtime: `ADA_CYCLE_IN_PROGRESS`, `ADA_WRONG_ROLE`, `ADA_GIT_DIRTY`, `ADA_GIT_CONFLICT`
    - Network: `ADA_GITHUB_UNAUTHORIZED`, `ADA_GITHUB_RATE_LIMIT`, `ADA_GITHUB_NOT_FOUND`, `ADA_NETWORK_OFFLINE`
    - Validation: `ADA_MISSING_ACTION`, `ADA_INVALID_ROLE`, `ADA_EMPTY_MEMORY`
  - Each code has: message template, suggestions, docs URL, exit code

- **ErrorBuilder** (`src/errors/builder.ts`)
  - Fluent API for constructing errors
  - `.context()`, `.detail()`, `.suggest()`, `.cause()` methods
  - `adaError('ADA_NOT_INITIALIZED').detail('file', 'x').build()`

- **Error Renderer** (`src/errors/renderer.ts`)
  - TTY output: colored with emoji (✖, 💡, 📖)
  - Plain output: CI-friendly format
  - JSON output: structured for scripting
  - Respects `NO_COLOR`, `FORCE_COLOR`, `CI`, `ADA_OUTPUT=json`

### Exit Codes
| Code | Category |
|------|----------|
| 0 | Success |
| 1 | General error |
| 2 | Usage/validation |
| 3 | Config |
| 4 | Runtime |
| 5 | Network |
| 6 | Git |

## Testing
- 99 tests added (4 test files)
- 100% coverage of error module
- All 1511 tests pass

## Checklist
- [x] Conventional commit title
- [x] Tests included
- [x] TypeScript strict mode passes
- [x] ESLint passes

---
*Author: ⚙️ Engineering (C1090)*