### PR TITLE
feat(web): add NextAuth.js integration for Sprint 3

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,7 +22,10 @@
   },
   "dependencies": {
     "@ada-ai/core": "*",
+    "@auth/prisma-adapter": "^2.7.0",
+    "@prisma/client": "^6.5.0",
     "next": "^15.5.12",
+    "next-auth": "^5.0.0-beta.28",
     "react": "*",
     "react-dom": "*",
     "lucide-react": "^0.344.0",
@@ -33,6 +36,7 @@
   "devDependencies": {
     "@playwright/test": "^1.51.0",
     "eslint-config-next": "^15.5.12",
+    "prisma": "^6.5.0",
     "@types/node": "^20.11.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",

--- a/apps/web/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,19 @@
+/**
+ * NextAuth.js API Route Handler
+ *
+ * Handles all authentication-related requests:
+ * - GET /api/auth/signin — Sign in page
+ * - POST /api/auth/signin/:provider — Initiate OAuth flow
+ * - GET /api/auth/callback/:provider — OAuth callback
+ * - GET /api/auth/signout — Sign out page
+ * - POST /api/auth/signout — Sign out action
+ * - GET /api/auth/session — Get current session
+ * - GET /api/auth/providers — List available providers
+ *
+ * @author ⚙️ Engineering (Cycle 1190)
+ * @see Sprint 3 Day 3-4 — AUTH-1 through AUTH-7
+ */
+
+import { handlers } from '@/lib/auth/auth';
+
+export const { GET, POST } = handlers;

--- a/apps/web/src/lib/auth/__tests__/auth.config.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.config.test.ts
@@ -1,0 +1,146 @@
+/**
+ * NextAuth.js Configuration Tests
+ *
+ * Tests for auth configuration and callbacks.
+ *
+ * @author ⚙️ Engineering (Cycle 1190)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { authConfig } from '../auth.config';
+
+describe('authConfig', () => {
+  describe('providers', () => {
+    it('should have GitHub provider configured', () => {
+      expect(authConfig.providers).toBeDefined();
+      expect(authConfig.providers.length).toBeGreaterThan(0);
+      // Provider is a function in NextAuth v5
+      const provider = authConfig.providers[0];
+      expect(provider).toBeDefined();
+    });
+  });
+
+  describe('pages', () => {
+    it('should have custom sign in page', () => {
+      expect(authConfig.pages?.signIn).toBe('/auth/signin');
+    });
+
+    it('should have custom sign out page', () => {
+      expect(authConfig.pages?.signOut).toBe('/auth/signout');
+    });
+
+    it('should have custom error page', () => {
+      expect(authConfig.pages?.error).toBe('/auth/error');
+    });
+  });
+
+  describe('session', () => {
+    it('should use database strategy', () => {
+      expect(authConfig.session?.strategy).toBe('database');
+    });
+
+    it('should have 30-day max age', () => {
+      expect(authConfig.session?.maxAge).toBe(30 * 24 * 60 * 60);
+    });
+
+    it('should update every 24 hours', () => {
+      expect(authConfig.session?.updateAge).toBe(24 * 60 * 60);
+    });
+  });
+
+  describe('callbacks.signIn', () => {
+    const signInCallback = authConfig.callbacks?.signIn;
+
+    it('should be defined', () => {
+      expect(signInCallback).toBeDefined();
+    });
+
+    it('should allow users with email', async () => {
+      if (!signInCallback) return;
+      const result = await signInCallback({
+        user: { id: '1', email: 'test@example.com' },
+        account: null,
+        profile: undefined,
+      });
+      expect(result).toBe(true);
+    });
+
+    it('should reject users without email', async () => {
+      if (!signInCallback) return;
+      const result = await signInCallback({
+        user: { id: '1', email: null },
+        account: null,
+        profile: undefined,
+      });
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('callbacks.session', () => {
+    const sessionCallback = authConfig.callbacks?.session;
+
+    it('should be defined', () => {
+      expect(sessionCallback).toBeDefined();
+    });
+
+    it('should add user id to session', async () => {
+      if (!sessionCallback) return;
+      const session = {
+        user: { name: 'Test', email: 'test@example.com' },
+        expires: new Date().toISOString(),
+      };
+      const user = {
+        id: 'user-123',
+        email: 'test@example.com',
+        tier: 'PRO' as const,
+        githubId: 'gh-456',
+      };
+
+      const result = await sessionCallback({
+        session,
+        user,
+        token: {},
+        trigger: 'update',
+        newSession: undefined,
+      });
+
+      expect(result.user.id).toBe('user-123');
+    });
+  });
+
+  describe('callbacks.redirect', () => {
+    const redirectCallback = authConfig.callbacks?.redirect;
+    const baseUrl = 'https://ada.ai';
+
+    it('should be defined', () => {
+      expect(redirectCallback).toBeDefined();
+    });
+
+    it('should handle relative paths', async () => {
+      if (!redirectCallback) return;
+      const result = await redirectCallback({
+        url: '/dashboard',
+        baseUrl,
+      });
+      expect(result).toBe(`${baseUrl}/dashboard`);
+    });
+
+    it('should allow same-origin URLs', async () => {
+      if (!redirectCallback) return;
+      const result = await redirectCallback({
+        url: `${baseUrl}/settings`,
+        baseUrl,
+      });
+      expect(result).toBe(`${baseUrl}/settings`);
+    });
+
+    it('should redirect cross-origin URLs to dashboard', async () => {
+      if (!redirectCallback) return;
+      const result = await redirectCallback({
+        url: 'https://evil.com/steal',
+        baseUrl,
+      });
+      expect(result).toBe(`${baseUrl}/dashboard`);
+    });
+  });
+});

--- a/apps/web/src/lib/auth/auth.config.ts
+++ b/apps/web/src/lib/auth/auth.config.ts
@@ -1,0 +1,177 @@
+/**
+ * NextAuth.js Configuration
+ *
+ * Core authentication configuration for the ADA SaaS platform.
+ * Uses GitHub OAuth as the primary authentication provider.
+ *
+ * @author ⚙️ Engineering (Cycle 1190)
+ * @see Sprint 3 Day 3-4 — AUTH-1 through AUTH-7
+ */
+
+import type { NextAuthConfig, Session, User, Account, Profile } from 'next-auth';
+import GitHub from 'next-auth/providers/github';
+
+import { AUTH_ENV, AUTH_URLS, SESSION_CONFIG, GITHUB_SCOPES } from './config';
+import type { Tier } from './types';
+
+/**
+ * Extended session user type with ADA fields
+ */
+interface ADASessionUser {
+  id?: string;
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+  tier?: Tier;
+  githubId?: string;
+}
+
+/**
+ * User from database adapter with ADA fields
+ */
+interface DatabaseUser {
+  id: string;
+  name?: string | null;
+  email?: string | null;
+  emailVerified?: Date | null;
+  image?: string | null;
+  tier?: Tier;
+  githubId?: string;
+}
+
+/** Callback params types */
+interface SignInParams {
+  user: User;
+  account: Account | null;
+  profile?: Profile;
+}
+
+interface SessionParams {
+  session: Session;
+  user?: User;
+  token?: unknown;
+}
+
+interface RedirectParams {
+  url: string;
+  baseUrl: string;
+}
+
+interface CreateUserParams {
+  user: User;
+}
+
+interface SignInEventParams {
+  user: User;
+  isNewUser?: boolean;
+  account?: Account | null;
+}
+
+/**
+ * NextAuth.js configuration object
+ * Used by auth() handler and middleware
+ */
+export const authConfig: NextAuthConfig = {
+  providers: [
+    GitHub({
+      clientId: AUTH_ENV.GITHUB_CLIENT_ID ?? '',
+      clientSecret: AUTH_ENV.GITHUB_CLIENT_SECRET ?? '',
+      authorization: {
+        params: {
+          scope: GITHUB_SCOPES.join(' '),
+        },
+      },
+    }),
+  ],
+
+  pages: {
+    signIn: AUTH_URLS.signIn,
+    signOut: AUTH_URLS.signOut,
+    error: AUTH_URLS.error,
+  },
+
+  session: {
+    strategy: 'database',
+    maxAge: SESSION_CONFIG.maxAge,
+    updateAge: SESSION_CONFIG.updateAge,
+  },
+
+  callbacks: {
+    /**
+     * Control who can sign in
+     * For now, allow all GitHub users
+     */
+    signIn: async (params: SignInParams): Promise<boolean> => {
+      const user = params.user as DatabaseUser;
+      // Require email for sign in
+      if (!user.email) {
+        return false;
+      }
+
+      // Future: Add allowlist check for beta period
+      // Future: Block users who have been banned
+
+      return true;
+    },
+
+    /**
+     * Customize session object sent to client
+     * Adds ADA-specific fields (tier, cyclesRemaining)
+     */
+    session: async (params: SessionParams): Promise<Session> => {
+      const { session } = params;
+      const user = params.user as DatabaseUser | undefined;
+
+      // user comes from database adapter
+      const sessionUser = session.user as ADASessionUser;
+      if (sessionUser && user) {
+        sessionUser.id = user.id;
+        sessionUser.tier = user.tier ?? 'FREE';
+        sessionUser.githubId = user.githubId;
+      }
+      return session;
+    },
+
+    /**
+     * Redirect after sign in/out
+     */
+    redirect: async (params: RedirectParams): Promise<string> => {
+      const { url, baseUrl } = params;
+      // Redirect to same origin only (security)
+      if (url.startsWith('/')) {
+        return `${baseUrl}${url}`;
+      }
+      if (new URL(url).origin === baseUrl) {
+        return url;
+      }
+      return baseUrl + AUTH_URLS.afterSignIn;
+    },
+  },
+
+  events: {
+    /**
+     * User created for the first time
+     */
+    createUser: async (params: CreateUserParams): Promise<void> => {
+      const user = params.user as DatabaseUser;
+      console.log(`[ADA Auth] New user created: ${user.email}`);
+      // Future: Send welcome email
+      // Future: Check waitlist for priority badge
+    },
+
+    /**
+     * User signed in
+     */
+    signIn: async (params: SignInEventParams): Promise<void> => {
+      const user = params.user as DatabaseUser;
+      const isNewUser = params.isNewUser;
+      console.log(
+        `[ADA Auth] User signed in: ${user.email} (new: ${isNewUser})`
+      );
+    },
+  },
+
+  debug: process.env.NODE_ENV === 'development',
+};
+
+export default authConfig;

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -1,0 +1,75 @@
+/**
+ * NextAuth.js Handler
+ *
+ * Main authentication handler with Prisma adapter.
+ * Exports auth(), signIn(), signOut() for use throughout the app.
+ *
+ * @author ⚙️ Engineering (Cycle 1190)
+ * @see Sprint 3 Day 3-4 — AUTH-1 through AUTH-7
+ */
+
+import NextAuth from 'next-auth';
+import { PrismaAdapter } from '@auth/prisma-adapter';
+
+import { prisma } from '../prisma';
+import { authConfig } from './auth.config';
+
+/**
+ * NextAuth.js handler with Prisma adapter
+ *
+ * The Prisma adapter automatically:
+ * - Creates users in the database on first sign in
+ * - Links OAuth accounts to users
+ * - Manages sessions in the database
+ * - Handles verification tokens
+ */
+export const {
+  handlers,
+  auth,
+  signIn,
+  signOut,
+} = NextAuth({
+  adapter: PrismaAdapter(prisma),
+  ...authConfig,
+});
+
+/**
+ * Type-safe session getter
+ * Use in server components and API routes
+ *
+ * @example
+ * ```tsx
+ * import { getSession } from '@/lib/auth/auth';
+ *
+ * export default async function Page() {
+ *   const session = await getSession();
+ *   if (!session) redirect('/auth/signin');
+ *   return <div>Hello {session.user.name}</div>;
+ * }
+ * ```
+ */
+export const getSession = auth;
+
+/**
+ * Type-safe session getter that throws if unauthenticated
+ * Use when you're certain the route requires auth
+ *
+ * @example
+ * ```tsx
+ * import { getRequiredSession } from '@/lib/auth/auth';
+ *
+ * export default async function DashboardPage() {
+ *   const session = await getRequiredSession(); // Throws if not authenticated
+ *   return <div>Hello {session.user.name}</div>;
+ * }
+ * ```
+ */
+export async function getRequiredSession() {
+  const session = await auth();
+  if (!session) {
+    throw new Error('Unauthenticated');
+  }
+  return session;
+}
+
+export default auth;

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -4,18 +4,25 @@
  * Authentication and authorization for the ADA SaaS platform.
  * Sprint 3 foundation for GitHub OAuth + Stripe billing.
  *
- * @author ⚙️ Engineering (Cycle 1180)
+ * @author ⚙️ Engineering (Cycle 1180, 1190)
  * @module @ada-ai/web/lib/auth
  *
  * @example
  * ```typescript
  * import {
- *   type SessionUser,
- *   type AuthContext,
+ *   auth,
+ *   getSession,
+ *   getRequiredSession,
+ *   signIn,
+ *   signOut,
  *   getPermissions,
  *   can,
  *   hasCyclesRemaining,
  * } from '@/lib/auth';
+ *
+ * // Get session in server component
+ * const session = await getSession();
+ * if (!session) redirect('/auth/signin');
  *
  * // Check permissions
  * const permissions = getPermissions(user, team);
@@ -89,3 +96,15 @@ export {
   AUTH_URLS,
   AUTH_FEATURES,
 } from './config';
+
+// NextAuth.js handlers and utilities (Cycle 1190)
+export {
+  auth,
+  signIn,
+  signOut,
+  handlers,
+  getSession,
+  getRequiredSession,
+} from './auth';
+
+export { authConfig } from './auth.config';

--- a/apps/web/src/lib/auth/next-auth.d.ts
+++ b/apps/web/src/lib/auth/next-auth.d.ts
@@ -1,0 +1,56 @@
+/**
+ * NextAuth.js Type Augmentations
+ *
+ * Extends NextAuth types with ADA-specific fields.
+ * These fields are added to the session via callbacks.
+ *
+ * @author ⚙️ Engineering (Cycle 1190)
+ * @see Sprint 3 Day 3-4
+ */
+
+import type { Tier } from './types';
+
+declare module 'next-auth' {
+  /**
+   * Extended User type with ADA fields
+   */
+  interface User {
+    /** User's subscription tier */
+    tier?: Tier;
+    /** GitHub user ID */
+    githubId?: string;
+    /** Cycles used this period */
+    cyclesUsed?: number;
+    /** Cycle limit (-1 = unlimited) */
+    cyclesLimit?: number;
+  }
+
+  /**
+   * Extended Session type with ADA fields
+   */
+  interface Session {
+    user: {
+      id: string;
+      name?: string | null;
+      email?: string | null;
+      image?: string | null;
+      /** User's subscription tier */
+      tier?: Tier;
+      /** GitHub user ID */
+      githubId?: string;
+    };
+  }
+}
+
+declare module '@auth/core/adapters' {
+  /**
+   * Adapter User with ADA fields
+   * Matches our Prisma schema
+   */
+  interface AdapterUser {
+    tier?: Tier;
+    githubId?: string;
+    cyclesUsed?: number;
+    cyclesLimit?: number;
+  }
+}

--- a/apps/web/src/lib/prisma.ts
+++ b/apps/web/src/lib/prisma.ts
@@ -1,0 +1,53 @@
+/**
+ * Prisma Client Singleton
+ *
+ * Prevents multiple Prisma Client instances in development
+ * due to hot module reloading.
+ *
+ * Note: Run `npx prisma generate` after installing dependencies
+ * to generate the Prisma Client types.
+ *
+ * @author ⚙️ Engineering (Cycle 1190)
+ * @see https://www.prisma.io/docs/guides/database/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { PrismaClient } = require('@prisma/client') as {
+  PrismaClient: new (options?: {
+    log?: ('query' | 'info' | 'warn' | 'error')[];
+  }) => PrismaClientType;
+};
+
+/**
+ * Prisma Client type
+ * This is a placeholder until `npx prisma generate` is run
+ */
+type PrismaClientType = {
+  $connect(): Promise<void>;
+  $disconnect(): Promise<void>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+};
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClientType | undefined;
+};
+
+/**
+ * Prisma Client instance
+ * Reuses existing instance in development to prevent connection exhaustion
+ */
+export const prisma: PrismaClientType =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log:
+      process.env.NODE_ENV === 'development'
+        ? ['query', 'error', 'warn']
+        : ['error'],
+  });
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}
+
+export default prisma;

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,65 @@
+/**
+ * NextAuth.js Middleware
+ *
+ * Protects routes that require authentication.
+ * Redirects unauthenticated users to sign in page.
+ *
+ * @author ⚙️ Engineering (Cycle 1190)
+ * @see Sprint 3 Day 3-4 — AUTH-4, AUTH-5
+ */
+
+import { auth } from '@/lib/auth/auth';
+import { AUTH_URLS } from '@/lib/auth/config';
+
+export default auth((req) => {
+  const isAuthenticated = !!req.auth;
+  const pathname = req.nextUrl.pathname;
+
+  // Protected routes — require authentication
+  const protectedPaths = [
+    '/dashboard',
+    '/settings',
+    '/cycles',
+    '/memory',
+    '/api/user',
+    '/api/repos',
+  ];
+
+  const isProtected = protectedPaths.some(
+    (path) => pathname.startsWith(path)
+  );
+
+  // Redirect to sign in if accessing protected route while unauthenticated
+  if (isProtected && !isAuthenticated) {
+    const signInUrl = new URL(AUTH_URLS.signIn, req.nextUrl.origin);
+    signInUrl.searchParams.set('callbackUrl', pathname);
+    return Response.redirect(signInUrl);
+  }
+
+  // Redirect to dashboard if already signed in and accessing auth pages
+  const authPages = ['/auth/signin', '/login'];
+  const isAuthPage = authPages.some((path) => pathname.startsWith(path));
+
+  if (isAuthPage && isAuthenticated) {
+    return Response.redirect(new URL(AUTH_URLS.afterSignIn, req.nextUrl.origin));
+  }
+});
+
+/**
+ * Matcher configuration
+ * Only run middleware on these paths (improves performance)
+ */
+export const config = {
+  matcher: [
+    // Protected routes
+    '/dashboard/:path*',
+    '/settings/:path*',
+    '/cycles/:path*',
+    '/memory/:path*',
+    '/api/user/:path*',
+    '/api/repos/:path*',
+    // Auth pages (for redirect when already signed in)
+    '/auth/:path*',
+    '/login',
+  ],
+};


### PR DESCRIPTION
## Summary

Implements NextAuth.js v5 with GitHub OAuth provider and Prisma adapter. This pre-Sprint work front-loads Day 3-4 implementation per L672/L690.

## Type of Change

- [x] feat — New feature

## Related Issues

- Relates to #181 (Auth System — GitHub OAuth Integration)
- Relates to #155 (SaaS Container)

## Changes Made

### Dependencies (`apps/web/package.json`)
- `next-auth@5.0.0-beta.28` — NextAuth.js v5 (Auth.js)
- `@auth/prisma-adapter@2.7.0` — Prisma adapter for NextAuth
- `@prisma/client@6.5.0` — Prisma Client
- `prisma@6.5.0` (dev) — Prisma CLI for migrations

### Prisma Client (`src/lib/prisma.ts`)
- Singleton pattern to prevent connection exhaustion in dev
- Configurable logging by environment

### NextAuth Configuration (`src/lib/auth/auth.config.ts`)
- GitHub OAuth provider with custom scopes
- Database session strategy (30-day max age)
- Custom pages (signin, signout, error)
- Callbacks: signIn (email required), session (adds tier, githubId), redirect (same-origin security)
- Events: createUser, signIn logging

### NextAuth Handler (`src/lib/auth/auth.ts`)
- Prisma adapter integration
- Exports: auth, signIn, signOut, handlers, getSession, getRequiredSession

### API Route (`src/app/api/auth/[...nextauth]/route.ts`)
- NextAuth route handler (GET, POST)
- Handles OAuth flow, sessions, providers

### Middleware (`src/middleware.ts`)
- Protects /dashboard, /settings, /cycles, /memory, /api/user, /api/repos
- Redirects unauthenticated users to signin
- Redirects authenticated users away from auth pages

### Type Augmentations (`src/lib/auth/next-auth.d.ts`)
- Extends User and Session with tier, githubId
- Extends AdapterUser for Prisma

### Tests (`src/lib/auth/__tests__/auth.config.test.ts`)
- 16 tests covering providers, pages, session, callbacks

## Acceptance Criteria Coverage

| ID | Criterion | Status |
|----|-----------|--------|
| AUTH-1 | Sign in with GitHub button | ✅ Route handler ready |
| AUTH-2 | OAuth flow completes | ✅ GitHub provider configured |
| AUTH-4 | Session persists | ✅ Database strategy |
| AUTH-5 | Sign out | ✅ Handlers exported |
| AUTH-6 | Error handling | ✅ Custom error page |

## Pre-Sprint Setup Remaining

1. Run `npx prisma generate` after `npm install`
2. Configure GitHub OAuth App in Vercel
3. Set environment variables:
   - `NEXTAUTH_SECRET`
   - `NEXTAUTH_URL`
   - `GITHUB_CLIENT_ID`
   - `GITHUB_CLIENT_SECRET`
   - `DATABASE_URL`

## Testing

- [x] `npm run typecheck` — All packages clean
- [x] `npm test --workspace=apps/web` — 47 tests pass (16 new)

## Checklist

- [x] Follows conventional commit format
- [x] Tests included (16 new tests)
- [x] TypeScript strict mode clean
- [x] JSDoc documentation included

---
**Author:** ⚙️ Engineering (Cycle 1190)